### PR TITLE
Fix flip modes for MINI12864

### DIFF
--- a/csrc/u8x8_d_uc1701_mini12864.c
+++ b/csrc/u8x8_d_uc1701_mini12864.c
@@ -82,16 +82,16 @@ static const uint8_t u8x8_d_uc1701_mini12864_powersave1_seq[] = {
 
 static const uint8_t u8x8_d_uc1701_mini12864_flip0_seq[] = {
   U8X8_START_TRANSFER(),             	/* enable chip, delay is part of the transfer start */
-  U8X8_C(0x0a1),				/* segment remap a0/a1*/
-  U8X8_C(0x0c0),				/* c0: scan dir normal, c8: reverse */
+  U8X8_C(0x0a0),				/* segment remap a0/a1*/
+  U8X8_C(0x0c8),				/* c0: scan dir normal, c8: reverse */
   U8X8_END_TRANSFER(),             	/* disable chip */
   U8X8_END()             			/* end of sequence */
 };
 
 static const uint8_t u8x8_d_uc1701_mini12864_flip1_seq[] = {
   U8X8_START_TRANSFER(),             	/* enable chip, delay is part of the transfer start */
-  U8X8_C(0x0a0),				/* segment remap a0/a1*/
-  U8X8_C(0x0c8),				/* c0: scan dir normal, c8: reverse */
+  U8X8_C(0x0a1),				/* segment remap a0/a1*/
+  U8X8_C(0x0c0),				/* c0: scan dir normal, c8: reverse */
   U8X8_END_TRANSFER(),             	/* disable chip */
   U8X8_END()             			/* end of sequence */
 };
@@ -115,7 +115,7 @@ static const u8x8_display_info_t u8x8_uc1701_display_info =
   /* tile_width = */ 16,		/* width of 16*8=128 pixel */
   /* tile_hight = */ 8,
   /* default_x_offset = */ 0,
-  /* flipmode_x_offset = */ 30,
+  /* flipmode_x_offset = */ 4,
   /* pixel_width = */ 128,
   /* pixel_height = */ 64
 };


### PR DESCRIPTION
- Swap original 'flip0' and 'flip1' to be consistent with the default
  settings
- Set flipmode_x_offset to 4