### PR TITLE
Preliminary Microchip XC8 compiler support

### DIFF
--- a/csrc/u8g2_input_value.c
+++ b/csrc/u8g2_input_value.c
@@ -144,6 +144,4 @@ uint8_t u8g2_UserInterfaceInputValue(u8g2_t *u8g2, const char *title, const char
       }        
     }
   }
-  
-  return r;  
 }

--- a/csrc/u8g2_message.c
+++ b/csrc/u8g2_message.c
@@ -190,7 +190,6 @@ uint8_t u8g2_UserInterfaceMessage(u8g2_t *u8g2, const char *title1, const char *
 	      break;
 	    }    
       }
-  }  
-  return 0;
+  }
 }
 

--- a/csrc/u8g2_polygon.c
+++ b/csrc/u8g2_polygon.c
@@ -70,7 +70,7 @@ static uint8_t pge_Next(struct pg_edge_struct *pge) PG_NOINLINE;
 static uint8_t pg_inc(pg_struct *pg, uint8_t i) PG_NOINLINE;
 static uint8_t pg_dec(pg_struct *pg, uint8_t i) PG_NOINLINE;
 static void pg_expand_min_y(pg_struct *pg, pg_word_t min_y, uint8_t pge_idx) PG_NOINLINE;
-static void pg_line_init(pg_struct * const pg, uint8_t pge_index) PG_NOINLINE;
+static void pg_line_init(pg_struct *pg, uint8_t pge_index) PG_NOINLINE;
 
 /*===========================================*/
 /* line draw algorithm */

--- a/csrc/u8x8_d_st7565.c
+++ b/csrc/u8x8_d_st7565.c
@@ -143,7 +143,7 @@ uint8_t u8x8_d_st7565_common(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *a
 	controller: It is not allowed to write beyond the display limits.
 	This is in fact an issue within flip mode.
       */
-      if ( c + x > 132u )
+      if ( ((uint16_t) (c + x)) > 132u )
       {
 	c = 132u;
 	c -= x;

--- a/csrc/u8x8_d_uc1701_dogs102.c
+++ b/csrc/u8x8_d_uc1701_dogs102.c
@@ -177,7 +177,7 @@ uint8_t u8x8_d_uc1701_ea_dogs102(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, voi
 	controller: It is not allowed to write beyond the display limits.
 	This is in fact an issue within flip mode.
       */
-      if ( c + x > 132u )
+      if ( ((uint16_t) (c + x)) > 132u )
       {
 	c = 132u;
 	c -= x;

--- a/csrc/u8x8_d_uc1701_mini12864.c
+++ b/csrc/u8x8_d_uc1701_mini12864.c
@@ -178,7 +178,7 @@ uint8_t u8x8_d_uc1701_mini12864(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void
 	controller: It is not allowed to write beyond the display limits.
 	This is in fact an issue within flip mode.
       */
-      if ( c + x > 132u )
+      if ( ((uint16_t) (c + x)) > 132u )
       {
 	c = 132u;
 	c -= x;


### PR DESCRIPTION
I know that this library is designed for use with GCC, but that did not stop me from trying to get this to work on a Microchip MCU using the XC8 compiler (free version). To be honest, it doesn't work (yet), but I think the following fixes are more or less general fixes.

I'll open another issue for the remaining problems.