### PR TITLE
Bitmaps: add bitmap mode

### DIFF
--- a/cppsrc/U8g2lib.h
+++ b/cppsrc/U8g2lib.h
@@ -185,6 +185,8 @@ class U8G2 : public Print
       { u8g2_DrawLine(&u8g2, x1, y1, x2, y2); }
 
     /* u8g2_bitmap.c */
+    void setBitmapMode(uint8_t is_transparent) 
+      { u8g2_SetBitmapMode(&u8g2, is_transparent); }
     void drawBitmap(u8g2_uint_t x, u8g2_uint_t y, u8g2_uint_t cnt, u8g2_uint_t h, const uint8_t *bitmap)
       { u8g2_DrawBitmap(&u8g2, x, y, cnt, h, bitmap); }
     void drawXBM(u8g2_uint_t x, u8g2_uint_t y, u8g2_uint_t w, u8g2_uint_t h, const uint8_t *bitmap)

--- a/csrc/u8g2.h
+++ b/csrc/u8g2.h
@@ -331,6 +331,7 @@ struct u8g2_struct
   
   int8_t glyph_x_offset;		/* set by u8g2_GetGlyphWidth as a side effect */
   
+  uint8_t bitmap_transparency;	/* black pixels will be treated as transparent (not drawn) */
 
   uint8_t draw_color;		/* 0: clear pixel, 1: set pixel, modified and restored by font procedures */
 					/* draw_color can be used also directly by the user API */
@@ -794,6 +795,7 @@ void u8g2_SetDrawColor(u8g2_t *u8g2, uint8_t color) U8G2_NOINLINE;  /* u8g: u8g_
 
 /*==========================================*/
 /* u8g2_bitmap.c */
+void u8g2_SetBitmapMode(u8g2_t *u8g2, uint8_t is_transparent);
 void u8g2_DrawHorizontalBitmap(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, u8g2_uint_t len, const uint8_t *b);
 void u8g2_DrawBitmap(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, u8g2_uint_t cnt, u8g2_uint_t h, const uint8_t *bitmap);
 void u8g2_DrawXBM(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, u8g2_uint_t w, u8g2_uint_t h, const uint8_t *bitmap);

--- a/csrc/u8g2_bitmap.c
+++ b/csrc/u8g2_bitmap.c
@@ -35,6 +35,11 @@
 
 #include "u8g2.h"
 
+
+void u8g2_SetBitmapMode(u8g2_t *u8g2, uint8_t is_transparent) {
+  u8g2->bitmap_transparency = is_transparent;
+}
+
 /*
   x,y 	Position on the display
   len		Length of bitmap line in pixel. Note: This differs from u8glib which had a bytecount here.
@@ -45,6 +50,9 @@
 void u8g2_DrawHorizontalBitmap(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, u8g2_uint_t len, const uint8_t *b)
 {
   uint8_t mask;
+  uint8_t color = u8g2->draw_color;
+  uint8_t ncolor = (color == 0 ? 1 : 0);
+
 #ifdef U8G2_WITH_INTERSECTION
   if ( u8g2_IsIntersection(u8g2, x, y, x+len, y+1) == 0 ) 
     return;
@@ -53,8 +61,14 @@ void u8g2_DrawHorizontalBitmap(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, u8g2_
   mask = 128;
   while(len > 0)
   {
-    if ( *b & mask )
+    if ( *b & mask ) {
+      u8g2->draw_color = color;
       u8g2_DrawHVLine(u8g2, x, y, 1, 0);
+    } else if ( u8g2->bitmap_transparency == 0 ) {
+      u8g2->draw_color = ncolor;
+      u8g2_DrawHVLine(u8g2, x, y, 1, 0);
+    }
+
     x++;
     mask >>= 1;
     if ( mask == 0 )
@@ -100,13 +114,14 @@ void u8g2_DrawHXBM(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, u8g2_uint_t len, 
 #endif /* U8G2_WITH_INTERSECTION */
   
   mask = 1;
-  while(len > 0)
-  {
-    if ( *b & mask )
+  while(len > 0) {
+    if ( *b & mask ) {
       u8g2->draw_color = color;
-    else
+      u8g2_DrawHVLine(u8g2, x, y, 1, 0);
+    } else if ( u8g2->bitmap_transparency == 0 ) {
       u8g2->draw_color = ncolor;
-    u8g2_DrawHVLine(u8g2, x, y, 1, 0);
+      u8g2_DrawHVLine(u8g2, x, y, 1, 0);
+    }
     x++;
     mask <<= 1;
     if ( mask == 0 )
@@ -158,11 +173,14 @@ void u8g2_DrawHXBMP(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, u8g2_uint_t len,
   mask = 1;
   while(len > 0)
   {
-    if ( u8x8_pgm_read(b) & mask )
+    if( u8x8_pgm_read(b) & mask ) {
       u8g2->draw_color = color;
-    else
+      u8g2_DrawHVLine(u8g2, x, y, 1, 0);
+    } else if( u8g2->bitmap_transparency == 0 ) {
       u8g2->draw_color = ncolor;
-    u8g2_DrawHVLine(u8g2, x, y, 1, 0);
+      u8g2_DrawHVLine(u8g2, x, y, 1, 0);
+    }
+   
     x++;
     mask <<= 1;
     if ( mask == 0 )

--- a/sys/arduino/u8g2_full_buffer/GraphicsTest/GraphicsTest.ino
+++ b/sys/arduino/u8g2_full_buffer/GraphicsTest/GraphicsTest.ino
@@ -254,6 +254,74 @@ void u8g2_extra_page(uint8_t a)
   }
 }
 
+#define cross_width 24
+#define cross_height 24
+static const unsigned char cross_bits[] U8X8_PROGMEM  = {
+  0x00, 0x18, 0x00, 0x00, 0x24, 0x00, 0x00, 0x24, 0x00, 0x00, 0x42, 0x00, 
+  0x00, 0x42, 0x00, 0x00, 0x42, 0x00, 0x00, 0x81, 0x00, 0x00, 0x81, 0x00, 
+  0xC0, 0x00, 0x03, 0x38, 0x3C, 0x1C, 0x06, 0x42, 0x60, 0x01, 0x42, 0x80, 
+  0x01, 0x42, 0x80, 0x06, 0x42, 0x60, 0x38, 0x3C, 0x1C, 0xC0, 0x00, 0x03, 
+  0x00, 0x81, 0x00, 0x00, 0x81, 0x00, 0x00, 0x42, 0x00, 0x00, 0x42, 0x00, 
+  0x00, 0x42, 0x00, 0x00, 0x24, 0x00, 0x00, 0x24, 0x00, 0x00, 0x18, 0x00, };
+
+#define cross_fill_width 24
+#define cross_fill_height 24
+static const unsigned char cross_fill_bits[] U8X8_PROGMEM  = {
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x18, 0x00, 0x18, 0x64, 0x00, 0x26, 
+  0x84, 0x00, 0x21, 0x08, 0x81, 0x10, 0x08, 0x42, 0x10, 0x10, 0x3C, 0x08, 
+  0x20, 0x00, 0x04, 0x40, 0x00, 0x02, 0x80, 0x00, 0x01, 0x80, 0x18, 0x01, 
+  0x80, 0x18, 0x01, 0x80, 0x00, 0x01, 0x40, 0x00, 0x02, 0x20, 0x00, 0x04, 
+  0x10, 0x3C, 0x08, 0x08, 0x42, 0x10, 0x08, 0x81, 0x10, 0x84, 0x00, 0x21, 
+  0x64, 0x00, 0x26, 0x18, 0x00, 0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, };
+
+#define cross_block_width 14
+#define cross_block_height 14
+static const unsigned char cross_block_bits[] U8X8_PROGMEM  = {
+  0xFF, 0x3F, 0x01, 0x20, 0x01, 0x20, 0x01, 0x20, 0x01, 0x20, 0x01, 0x20, 
+  0xC1, 0x20, 0xC1, 0x20, 0x01, 0x20, 0x01, 0x20, 0x01, 0x20, 0x01, 0x20, 
+  0x01, 0x20, 0xFF, 0x3F, };
+
+void u8g2_bitmap_overlay(uint8_t a) {
+  uint8_t frame_size = 28;
+
+  u8g2.drawStr(0, 0, "Bitmap overlay");
+
+  u8g2.drawStr(0, frame_size + 12, "Solid / transparent");
+  u8g2.setBitmapMode(false /* solid */);
+  u8g2.drawFrame(0, 10, frame_size, frame_size);
+  u8g2.drawXBMP(2, 12, cross_width, cross_height, cross_bits);
+  if(a & 4)
+    u8g2.drawXBMP(7, 17, cross_block_width, cross_block_height, cross_block_bits);
+
+  u8g2.setBitmapMode(true /* transparent*/);
+  u8g2.drawFrame(frame_size + 5, 10, frame_size, frame_size);
+  u8g2.drawXBMP(frame_size + 7, 12, cross_width, cross_height, cross_bits);
+  if(a & 4)
+    u8g2.drawXBMP(frame_size + 12, 17, cross_block_width, cross_block_height, cross_block_bits);
+}
+
+void u8g2_bitmap_modes(uint8_t transparent) {
+  const uint8_t frame_size = 24;
+
+  u8g2.drawBox(0, frame_size * 0.5, frame_size * 5, frame_size);
+  u8g2.drawStr(frame_size * 0.5, 50, "Black");
+  u8g2.drawStr(frame_size * 2, 50, "White");
+  u8g2.drawStr(frame_size * 3.5, 50, "XOR");
+  
+  if(!transparent) {
+    u8g2.setBitmapMode(false /* solid */);
+    u8g2.drawStr(0, 0, "Solid bitmap");
+  } else {
+    u8g2.setBitmapMode(true /* transparent*/);
+    u8g2.drawStr(0, 0, "Transparent bitmap");
+  }
+  u8g2.setDrawColor(0);// Black
+  u8g2.drawXBMP(frame_size * 0.5, 24, cross_width, cross_height, cross_bits);
+  u8g2.setDrawColor(1); // White
+  u8g2.drawXBMP(frame_size * 2, 24, cross_width, cross_height, cross_bits);
+  u8g2.setDrawColor(2); // XOR
+  u8g2.drawXBMP(frame_size * 3.5, 24, cross_width, cross_height, cross_bits);
+}
 
 uint8_t draw_state = 0;
 
@@ -269,6 +337,9 @@ void draw(void) {
     case 6: u8g2_ascii_1(); break;
     case 7: u8g2_ascii_2(); break;
     case 8: u8g2_extra_page(draw_state&7); break;
+    case 9: u8g2_bitmap_modes(0); break;
+    case 10: u8g2_bitmap_modes(1); break;
+    case 11: u8g2_bitmap_overlay(draw_state&7); break;
   }
 }
 
@@ -285,7 +356,7 @@ void loop(void) {
   
   // increase the state
   draw_state++;
-  if ( draw_state >= 9*8 )
+  if ( draw_state >= 12*8 )
     draw_state = 0;
 
   // deley between each page

--- a/sys/arduino/u8g2_page_buffer/GraphicsTest/GraphicsTest.ino
+++ b/sys/arduino/u8g2_page_buffer/GraphicsTest/GraphicsTest.ino
@@ -280,6 +280,75 @@ void u8g2_xor(uint8_t a) {
     
 }
 
+#define cross_width 24
+#define cross_height 24
+static const unsigned char cross_bits[] U8X8_PROGMEM  = {
+  0x00, 0x18, 0x00, 0x00, 0x24, 0x00, 0x00, 0x24, 0x00, 0x00, 0x42, 0x00, 
+  0x00, 0x42, 0x00, 0x00, 0x42, 0x00, 0x00, 0x81, 0x00, 0x00, 0x81, 0x00, 
+  0xC0, 0x00, 0x03, 0x38, 0x3C, 0x1C, 0x06, 0x42, 0x60, 0x01, 0x42, 0x80, 
+  0x01, 0x42, 0x80, 0x06, 0x42, 0x60, 0x38, 0x3C, 0x1C, 0xC0, 0x00, 0x03, 
+  0x00, 0x81, 0x00, 0x00, 0x81, 0x00, 0x00, 0x42, 0x00, 0x00, 0x42, 0x00, 
+  0x00, 0x42, 0x00, 0x00, 0x24, 0x00, 0x00, 0x24, 0x00, 0x00, 0x18, 0x00, };
+
+#define cross_fill_width 24
+#define cross_fill_height 24
+static const unsigned char cross_fill_bits[] U8X8_PROGMEM  = {
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x18, 0x00, 0x18, 0x64, 0x00, 0x26, 
+  0x84, 0x00, 0x21, 0x08, 0x81, 0x10, 0x08, 0x42, 0x10, 0x10, 0x3C, 0x08, 
+  0x20, 0x00, 0x04, 0x40, 0x00, 0x02, 0x80, 0x00, 0x01, 0x80, 0x18, 0x01, 
+  0x80, 0x18, 0x01, 0x80, 0x00, 0x01, 0x40, 0x00, 0x02, 0x20, 0x00, 0x04, 
+  0x10, 0x3C, 0x08, 0x08, 0x42, 0x10, 0x08, 0x81, 0x10, 0x84, 0x00, 0x21, 
+  0x64, 0x00, 0x26, 0x18, 0x00, 0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, };
+
+#define cross_block_width 14
+#define cross_block_height 14
+static const unsigned char cross_block_bits[] U8X8_PROGMEM  = {
+  0xFF, 0x3F, 0x01, 0x20, 0x01, 0x20, 0x01, 0x20, 0x01, 0x20, 0x01, 0x20, 
+  0xC1, 0x20, 0xC1, 0x20, 0x01, 0x20, 0x01, 0x20, 0x01, 0x20, 0x01, 0x20, 
+  0x01, 0x20, 0xFF, 0x3F, };
+
+void u8g2_bitmap_overlay(uint8_t a) {
+  uint8_t frame_size = 28;
+
+  u8g2.drawStr(0, 0, "Bitmap overlay");
+
+  u8g2.drawStr(0, frame_size + 12, "Solid / transparent");
+  u8g2.setBitmapMode(false /* solid */);
+  u8g2.drawFrame(0, 10, frame_size, frame_size);
+  u8g2.drawXBMP(2, 12, cross_width, cross_height, cross_bits);
+  if(a & 4)
+    u8g2.drawXBMP(7, 17, cross_block_width, cross_block_height, cross_block_bits);
+
+  u8g2.setBitmapMode(true /* transparent*/);
+  u8g2.drawFrame(frame_size + 5, 10, frame_size, frame_size);
+  u8g2.drawXBMP(frame_size + 7, 12, cross_width, cross_height, cross_bits);
+  if(a & 4)
+    u8g2.drawXBMP(frame_size + 12, 17, cross_block_width, cross_block_height, cross_block_bits);
+}
+
+void u8g2_bitmap_modes(uint8_t transparent) {
+  const uint8_t frame_size = 24;
+
+  u8g2.drawBox(0, frame_size * 0.5, frame_size * 5, frame_size);
+  u8g2.drawStr(frame_size * 0.5, 50, "Black");
+  u8g2.drawStr(frame_size * 2, 50, "White");
+  u8g2.drawStr(frame_size * 3.5, 50, "XOR");
+  
+  if(!transparent) {
+    u8g2.setBitmapMode(false /* solid */);
+    u8g2.drawStr(0, 0, "Solid bitmap");
+  } else {
+    u8g2.setBitmapMode(true /* transparent*/);
+    u8g2.drawStr(0, 0, "Transparent bitmap");
+  }
+  u8g2.setDrawColor(0);// Black
+  u8g2.drawXBMP(frame_size * 0.5, 24, cross_width, cross_height, cross_bits);
+  u8g2.setDrawColor(1); // White
+  u8g2.drawXBMP(frame_size * 2, 24, cross_width, cross_height, cross_bits);
+  u8g2.setDrawColor(2); // XOR
+  u8g2.drawXBMP(frame_size * 3.5, 24, cross_width, cross_height, cross_bits);
+}
+
 uint8_t draw_state = 0;
 
 void draw(void) {
@@ -296,6 +365,9 @@ void draw(void) {
     case 8: u8g2_ascii_2(); break;
     case 9: u8g2_extra_page(draw_state&7); break;
     case 10: u8g2_xor(draw_state&7); break;
+    case 11: u8g2_bitmap_modes(0); break;
+    case 12: u8g2_bitmap_modes(1); break;
+    case 13: u8g2_bitmap_overlay(draw_state&7); break;
   }
 }
 
@@ -329,10 +401,10 @@ void loop(void) {
   
   // increase the state
   draw_state++;
-  if ( draw_state >= 11*8 )
+  if ( draw_state >= 14*8 )
     draw_state = 0;
 
   // delay between each page
-  delay(100);
+  delay(150);
 
 }


### PR DESCRIPTION
This new mode work in the same way as the existing font mode: It allows drawing
solid (both white and black pixels in the bitmap affect the output) or
transparent (only white pixels in the bitmap affect the output). Transparent
bitmaps may be used to draw multiple bitmaps over each other, for example when
drawing animations. As a side effect, transparent XOR mode now also works by
setting the bitmap mode to transparent and the draw color to 2.

Before this commit, the bitmaps XBM bitmaps were being drawn as solid
object, while the regular bitmaps were drawn as transparent.

The structure of the code is based on how `u8g2_font_decode_len()` handles the
same thing when drawing glyphs.