### PR TITLE
Contrast command wrong

### DIFF
--- a/csrc/u8x8_d_ssd1322.c
+++ b/csrc/u8x8_d_ssd1322.c
@@ -200,8 +200,8 @@ uint8_t u8x8_d_ssd1322_common(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *
 #ifdef U8X8_WITH_SET_CONTRAST
     case U8X8_MSG_DISPLAY_SET_CONTRAST:
       u8x8_cad_StartTransfer(u8x8);
-      u8x8_cad_SendCmd(u8x8, 0x081 );
-      u8x8_cad_SendArg(u8x8, arg_int );	/* ssd1325 has range from 0 to 255 */
+      u8x8_cad_SendCmd(u8x8, 0x0C1 );
+      u8x8_cad_SendArg(u8x8, arg_int );	/* ssd1322 has range from 0 to 255 */
       u8x8_cad_EndTransfer(u8x8);
       break;
 #endif


### PR DESCRIPTION
The command for the contrast should be 0xC1h according to datasheet

Now works but poor range, maybe other driving parameters can be set to allow better range.