### PR TITLE
Declared "weak" (only for GCC) the function u8x8_GetMenuEvent

### DIFF
--- a/csrc/u8x8_debounce.c
+++ b/csrc/u8x8_debounce.c
@@ -136,6 +136,9 @@ uint8_t u8x8_GetMenuEvent(u8x8_t *u8x8)
 #define U8X8_DEBOUNCE_WAIT 2
 /* do debounce and return a GPIO msg which indicates the event */
 /* returns 0, if there is no event */
+#ifdef  __GNUC__
+# pragma weak  u8x8_GetMenuEvent
+#endif
 uint8_t u8x8_GetMenuEvent(u8x8_t *u8x8)
 {
   uint8_t pin_state;


### PR DESCRIPTION
In this way anyone has the necessity  to customize the input device for userInterfaceSelectionList function (or each other function) he is not obligated ad modify the library.
The "weak" attribute can be used also for other compiler, each compiler has its syntax for "weak".
I used it to define in my code the function u8x8_GetMenuEvent which manages an encoder with push button as input interface.

This patch (method) doesn't change in any way the library and its functionalities. It give only more possibility to the user (for now only to the GCC user).

Ciao