### PR TITLE
Do not use weak symbols on CYGWIN

### DIFF
--- a/csrc/u8x8_debounce.c
+++ b/csrc/u8x8_debounce.c
@@ -136,7 +136,7 @@ uint8_t u8x8_GetMenuEvent(u8x8_t *u8x8)
 #define U8X8_DEBOUNCE_WAIT 2
 /* do debounce and return a GPIO msg which indicates the event */
 /* returns 0, if there is no event */
-#ifdef  __GNUC__
+#if defined(__GNUC__) && !defined(__CYGWIN__)
 # pragma weak  u8x8_GetMenuEvent
 #endif
 uint8_t u8x8_GetMenuEvent(u8x8_t *u8x8)


### PR DESCRIPTION
Apparently CYGWIN does not properly support these, the weak
u8x8_GetMenuEvent() symbol is not found by the linker during
the link step.