### PR TITLE
Bytes are traditionally 8 bits long, at least on my st7920

### DIFF
--- a/csrc/u8x8_byte.c
+++ b/csrc/u8x8_byte.c
@@ -266,7 +266,7 @@ uint8_t u8x8_byte_3wire_sw_spi(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void 
 	  b |= 256;
 	data++;
 	arg_int--;
-	for( i = 0; i < 9; i++ )
+	for( i = 0; i < 8; i++ )
 	{
 	  if ( b & 256 )
 	    u8x8_gpio_SetSPIData(u8x8, 1);


### PR DESCRIPTION
Hi, I have no idea where the 9 bits per byte code came from, but it certainly didn't work with my st7920.

After I changed the 9 to an 8 it started working correctly.
