### PR TITLE
Cast to unsigned int to fix sign compare error.

### DIFF
--- a/sys/sdl/common/u8x8_d_sdl_128x64.c
+++ b/sys/sdl/common/u8x8_d_sdl_128x64.c
@@ -38,7 +38,7 @@ static void u8g_sdl_set_pixel(int x, int y, int idx)
       offset = 
 	(y * u8g_sdl_multiple + j) * u8g_sdl_screen->w * u8g_sdl_screen->format->BytesPerPixel + 
 	(x * u8g_sdl_multiple + i) * u8g_sdl_screen->format->BytesPerPixel;
-      assert( offset < u8g_sdl_screen->w * u8g_sdl_screen->h * u8g_sdl_screen->format->BytesPerPixel );
+      assert( offset < (Uint32)(u8g_sdl_screen->w * u8g_sdl_screen->h * u8g_sdl_screen->format->BytesPerPixel) );
       ptr = u8g_sdl_screen->pixels + offset;
       *ptr = u8g_sdl_color[idx];
     }


### PR DESCRIPTION
This PR fixes a compile error I encountered using RIOT-OS and SDL virtual output:

```
u8g2/sys/sdl/common/u8x8_d_sdl_128x64.c:41:22: error: comparison of
      integers of different signs: 'Uint32' (aka 'unsigned int') and 'int' [-Werror,-Wsign-compare]
      assert( offset < u8g_sdl_screen->w * u8g_sdl_screen->h * u8g_sdl_screen->format->BytesPerPixel );
```