### PR TITLE
Significantly speed up glyph lookups for CJK fonts

### DIFF
--- a/csrc/u8g2.h
+++ b/csrc/u8g2.h
@@ -147,8 +147,10 @@
 */
 #define U8G2_WITH_CLIPPING
 
+// Glyph lookup cache (0 - disabled; 1 - last encoding; 2 - indexed space)
+#define U8G2_WITH_GLYPH_LOOKUP_CACHE 2
 
-
+#define U8G2_INDEX_CNT_UNICODE 8
 
 /*==========================================*/
 
@@ -344,11 +346,13 @@ struct u8g2_struct
 #ifdef U8G2_WITH_HVLINE_COUNT
   unsigned long hv_cnt;
 #endif /* U8G2_WITH_HVLINE_COUNT */   
-#ifdef __unix__
+#if U8G2_WITH_GLYPH_LOOKUP_CACHE == 1
+  const uint8_t *last_unicode_glyph;
   uint16_t last_unicode;
-  const uint8_t *last_font_data;
+#elif U8G2_WITH_GLYPH_LOOKUP_CACHE == 2
+  uint16_t index_unicode[U8G2_INDEX_CNT_UNICODE];
+  const uint8_t *index_unicode_glyphs[U8G2_INDEX_CNT_UNICODE];
 #endif
-
 };
 
 #define u8g2_GetU8x8(u8g2) ((u8x8_t *)(u8g2))


### PR DESCRIPTION
This is a refresh of PR #590, with only the glyph lookup performance enhancement.

Configuration and corresponding performance (profiled using `Shennong` example on ESP8266 @ 80MHz):

- U8G2_WITH_GLYPH_LOOKUP_CACHE = 0
    This configuration is the baseline of existing code:
    Avg time for drawing a frame: 566ms, worst 864ms

- U8G2_WITH_GLYPH_LOOKUP_CACHE = 1
    This configuration enables cache of last successful looked up encoding
    The machanism already exists in existing code, but somehow disabled by the __unix__ macro
    I only cleaned up the code a little bit, and verified it actually works.
    Avg time for drawing a frame: 410ms, worst 615ms (1.38x speedup)

- U8G2_WITH_GLYPH_LOOKUP_CACHE = 2 (default in this PR)
   This configuration enables fixed point lookup indices.
   The unicode glyph space is divided in to a configurable U8G2_INDEX_CNT_UNICODE +1 partitions, reducing the amount of linear scans when finding glyph of a symbol.
   The memory cost is 6 bytes * U8G2_INDEX_CNT_UNICODE .
   - U8G2_INDEX_CNT_UNICODE = 4:  24 bytes extra memory, 4.3x speedup
   - U8G2_INDEX_CNT_UNICODE = 8 (default in this PR):  48 bytes extra memory, 7.1x speedup
   - U8G2_INDEX_CNT_UNICODE = 16:  96 bytes extra memory, 12.9x speedup
   - U8G2_INDEX_CNT_UNICODE = 32:  192 bytes extra memory, 20.2x speedup
