### PR TITLE
Set page (row) address correctly for st75256_jlx256160

### DIFF
--- a/csrc/u8x8_d_st75256.c
+++ b/csrc/u8x8_d_st75256.c
@@ -883,8 +883,8 @@ static const u8x8_display_info_t u8x8_st75256_256x160_display_info =
   /* write_pulse_width_ns = */ 70,	
   /* tile_width = */ 32,
   /* tile_hight = */ 20,
-  /* default_x_offset = */ 0,	/*  x offset in flipmode 0 */
-  /* flipmode_x_offset = */ 0,		/* */
+  /* default_x_offset = */ 0,	/* */
+  /* flipmode_x_offset = */ 1,		/* x offset in flipmode = 1 */
   /* pixel_width = */ 256,
   /* pixel_height = */ 160
 };
@@ -931,8 +931,8 @@ static const uint8_t u8x8_d_st75256_256x160_init_seq[] = {
  
   
   U8X8_C( 0x030 ),				/* select 00 commands */
-  U8X8_CAA(0x75, 0, 0x4f),		/* row range */
-  U8X8_CAA(0x15, 0, 255),		/* col range */
+  U8X8_CAA(0x75, 0, 0x28),		/* row range */
+  U8X8_CAA(0x15, 0, 0xFF),		/* col range */
   
   //U8X8_C( 0x030 ),				/* select 00 commands */
   U8X8_CA( 0xbc, 0x02 ),			/* data scan dir */
@@ -977,7 +977,7 @@ uint8_t u8x8_d_st75256_jlx256160(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, voi
               
               u8x8_cad_SendCmd(u8x8, 0x030 );	/* select command set */
               u8x8_cad_SendCmd(u8x8, 0x075 );	/* row */
-	      if ( u8x8->x_offset == 0 )		/* 0 means flip mode 1 */
+	      if ( u8x8->x_offset == 1 )		/* 1 means flip mode 1 */
 		u8x8_cad_SendArg(u8x8, 1+(((u8x8_tile_t *)arg_ptr)->y_pos));
 	      else
 		u8x8_cad_SendArg(u8x8, (((u8x8_tile_t *)arg_ptr)->y_pos));

--- a/csrc/u8x8_d_st75256.c
+++ b/csrc/u8x8_d_st75256.c
@@ -883,8 +883,8 @@ static const u8x8_display_info_t u8x8_st75256_256x160_display_info =
   /* write_pulse_width_ns = */ 70,	
   /* tile_width = */ 32,
   /* tile_hight = */ 20,
-  /* default_x_offset = */ 0,	/* */
-  /* flipmode_x_offset = */ 1,		/* x offset in flipmode = 1 */
+  /* default_x_offset = */ 0,
+  /* flipmode_x_offset = */ 1,	/* x offset is used as y offset in flipmode */
   /* pixel_width = */ 256,
   /* pixel_height = */ 160
 };
@@ -984,7 +984,7 @@ uint8_t u8x8_d_st75256_jlx256160(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, voi
               u8x8_cad_SendArg(u8x8, 0x04f);
               //u8x8_cad_SendArg(u8x8, (((u8x8_tile_t *)arg_ptr)->y_pos));
               u8x8_cad_SendCmd(u8x8, 0x015 );	/* col */
-              u8x8_cad_SendArg(u8x8, x+u8x8->x_offset);
+              u8x8_cad_SendArg(u8x8, x+u8x8->display_info->default_x_offset);
               u8x8_cad_SendArg(u8x8, 255);
               u8x8_cad_SendCmd(u8x8, 0x05c );	
             


### PR DESCRIPTION
I hooked up one of these displays [purchased here](https://www.aliexpress.com/item/20PIN-SPI-COG-12864-LCD-Module-with-Chinese-Font-ST7567R-Drive-IC-3-3V-White-Backlight/32608104073.html). 

Using the MIRROR rotation worked but produced garbage data at the top.

![screenshot_2018-10-02_19-34-52](https://user-images.githubusercontent.com/37681/46387210-7f5e5b00-c67a-11e8-8cfa-fb166e341cc0.png)

This pull request sets the y offset correctly for default and flip mode.

![screenshot_2018-10-02_19-35-23](https://user-images.githubusercontent.com/37681/46387233-99983900-c67a-11e8-8727-d0d027984b99.png)

Here is a [photo album of all rotations](https://photos.app.goo.gl/baackYN8VwBMCJfN7). Images are:
before fix R0, R1, R2, R3, MIRROR, MIRROR + setFlipMode(1)
after fix R0, R1, R2, R3, MIRROR, MIRROR + setFlipMode(1)

![rotation_images](https://user-images.githubusercontent.com/37681/46387800-5d1a0c80-c67d-11e8-9fcb-f82db8dd2ca8.png)

Arduino sketch code used:

```c++
#include <Arduino.h>

#define U8X8_HAVE_HW_SPI
#define U8G2_16BIT

#include <SPI.h>

#include <U8g2lib.h>

// Printing with stream operator
template<class T> inline Print& operator <<(Print &obj,     T arg) { obj.print(arg);    return obj; }
template<>        inline Print& operator <<(Print &obj, float arg) { obj.print(arg, 4); return obj; }

static const uint16_t gamma_table_2_5[] = {
	/* gamma = 2.5 */
	0,	0,	0,	1,	2,	4,	6,	8,
	11,	15,	20,	25,	31,	38,	46,	55,
	65,	75,	87,	99,	113,	128,	143,	160,
	178,	197,	218,	239,	262,	286,	311,	338,
	366,	395,	425,	457,	491,	526,	562,	599,
	639,	679,	722,	765,	811,	857,	906,	956,
	1007,	1061,	1116,	1172,	1231,	1291,	1352,	1416,
	1481,	1548,	1617,	1688,	1760,	1834,	1910,	1988,
	2068,	2150,	2233,	2319,	2407,	2496,	2587,	2681,
	2776,	2874,	2973,	3075,	3178,	3284,	3391,	3501,
	3613,	3727,	3843,	3961,	4082,	4204,	4329,	4456,
	4585,	4716,	4850,	4986,	5124,	5264,	5407,	5552,
	5699,	5849,	6001,	6155,	6311,	6470,	6632,	6795,
	6962,	7130,	7301,	7475,	7650,	7829,	8009,	8193,
	8379,	8567,	8758,	8951,	9147,	9345,	9546,	9750,
	9956,	10165,	10376,	10590,	10806,	11025,	11247,	11472,
	11699,	11929,	12161,	12397,	12634,	12875,	13119,	13365,
	13614,	13865,	14120,	14377,	14637,	14899,	15165,	15433,
	15705,	15979,	16256,	16535,	16818,	17104,	17392,	17683,
	17978,	18275,	18575,	18878,	19184,	19493,	19805,	20119,
	20437,	20758,	21082,	21409,	21739,	22072,	22407,	22746,
	23089,	23434,	23782,	24133,	24487,	24845,	25206,	25569,
	25936,	26306,	26679,	27055,	27435,	27818,	28203,	28592,
	28985,	29380,	29779,	30181,	30586,	30994,	31406,	31820,
	32239,	32660,	33085,	33513,	33944,	34379,	34817,	35258,
	35702,	36150,	36602,	37056,	37514,	37976,	38441,	38909,
	39380,	39856,	40334,	40816,	41301,	41790,	42282,	42778,
	43277,	43780,	44286,	44795,	45308,	45825,	46345,	46869,
	47396,	47927,	48461,	48999,	49540,	50085,	50634,	51186,
	51742,	52301,	52864,	53431,	54001,	54575,	55153,	55734,
	56318,	56907,	57499,	58095,	58695,	59298,	59905,	60515,
	61130,	61748,	62370,	62995,	63624,	64258,	64894,	65535,
};

U8G2_ST75256_JLX256160_F_4W_HW_SPI u8g2 = U8G2_ST75256_JLX256160_F_4W_HW_SPI(U8G2_MIRROR, 10, 9, 8);

uint8_t m = 24;

uint8_t brightness = 0;

void set_brightness(uint8_t b) {
  analogWrite(22, 65535-gamma_table_2_5[b]);
}

void setup(void) {
  SPI.begin();
  u8g2.begin();
  u8g2.setContrast(155);
  // u8g2.setFlipMode(1);
  analogWriteResolution(16);
  set_brightness(200);
}

void loop(void) {
  char m_str[3];
  strcpy(m_str, u8x8_u8toa(m, 2));		/* convert m to a string with two digits */

  u8g2.setFontDirection(0);
  u8g2.clearBuffer();
  u8g2.setCursor(0, 15);
  u8g2.setFont(u8g2_font_logisoso62_tn);
  u8g2.drawStr(0,63,"9");
  u8g2.drawStr(33,63,":");
  u8g2.drawStr(50,63,m_str);
  u8g2.drawRFrame(0, 0, 256, 160, 5);
  u8g2.sendBuffer();

  delay(1000);
  m++;
  if ( m == 60 )
    m = 0;
}
```
