### PR TITLE
fix jlx256160 flip mode sequences

### DIFF
--- a/csrc/u8x8_d_st75256.c
+++ b/csrc/u8x8_d_st75256.c
@@ -129,6 +129,29 @@ static const uint8_t u8x8_d_st75256_jlx172104_flip1_seq[] = {
   U8X8_END()             			/* end of sequence */
 };
 
+static const uint8_t u8x8_d_st75256_jlx256160_flip0_seq[] = {
+  U8X8_START_TRANSFER(),             	/* enable chip, delay is part of the transfer start */
+  U8X8_C( 0x030 ),				/* select 00 commands */
+  U8X8_CA( 0xbc, 0x00 ),			/* data scan dir */
+  U8X8_A( 0xa6 ),				/* ??? */
+
+  //U8X8_C( 0x030 ),				/* select 00 commands */
+  U8X8_C( 0x00c ),				/* data format LSB top */
+  U8X8_END_TRANSFER(),             	/* disable chip */
+  U8X8_END()             			/* end of sequence */
+};
+
+static const uint8_t u8x8_d_st75256_jlx256160_flip1_seq[] = {
+  U8X8_START_TRANSFER(),             	/* enable chip, delay is part of the transfer start */
+  U8X8_C( 0x030 ),				/* select 00 commands */
+  U8X8_CA( 0xbc, 0x03 ),			/* data scan dir */
+  U8X8_A( 0xa6 ),				/* ??? */
+
+  //U8X8_C( 0x030 ),				/* select 00 commands */
+  U8X8_C( 0x008 ),				/* data format MSB top */
+  U8X8_END_TRANSFER(),             	/* disable chip */
+  U8X8_END()             			/* end of sequence */
+};
 
 
 static uint8_t u8x8_d_st75256_256x128_generic(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr)
@@ -935,7 +958,7 @@ static const uint8_t u8x8_d_st75256_256x160_init_seq[] = {
   U8X8_CAA(0x15, 0, 0xFF),		/* col range */
   
   //U8X8_C( 0x030 ),				/* select 00 commands */
-  U8X8_CA( 0xbc, 0x02 ),			/* data scan dir */
+  U8X8_CA( 0xbc, 0x00 ),			/* data scan dir */
   U8X8_A( 0xa6 ),				/* ??? */
 
   //U8X8_C( 0x030 ),				/* select 00 commands */
@@ -1025,12 +1048,12 @@ uint8_t u8x8_d_st75256_jlx256160(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, voi
 	case U8X8_MSG_DISPLAY_SET_FLIP_MODE:
 	    if ( arg_int == 0 )
 	    {
-	      u8x8_cad_SendSequence(u8x8, u8x8_d_st75256_jlx172104_flip0_seq);	 // or u8x8_d_st75256_jlx256128_flip0_seq?
+	      u8x8_cad_SendSequence(u8x8, u8x8_d_st75256_jlx256160_flip0_seq);
 	      u8x8->x_offset = u8x8->display_info->default_x_offset;
 	    }
 	    else
 	    {
-	      u8x8_cad_SendSequence(u8x8, u8x8_d_st75256_jlx172104_flip1_seq);	 // or u8x8_d_st75256_jlx256128_flip1_seq?
+	      u8x8_cad_SendSequence(u8x8, u8x8_d_st75256_jlx256160_flip1_seq);
 	      u8x8->x_offset = u8x8->display_info->flipmode_x_offset;
 	    }
 	    return 1;
@@ -1247,4 +1270,4 @@ uint8_t u8x8_d_st75256_jlx256160_alt(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int,
   
   
   
-}
+} 


### PR DESCRIPTION
Followup to #716 and fixes #717. Thanks for the pointers!
Here are the images using the same arduino code as shown in https://github.com/olikraus/u8g2/pull/716#issuecomment-433728745

![screenshot_2018-10-29_09-20-02](https://user-images.githubusercontent.com/37681/47664473-5daea180-db5c-11e8-87e8-f810f89346a6.png)
![screenshot_2018-10-29_09-20-19](https://user-images.githubusercontent.com/37681/47664496-6d2dea80-db5c-11e8-9e0d-b6a04e64172f.png)

Data scan direction (0xBC) is set to 0x00 for flip0 and 0x03 for flip1. This makes sense from looking at the [datasheet](https://www.crystalfontz.com/controllers/Sitronix/ST75256/409/).

![screenshot_2018-10-29_09-26-28](https://user-images.githubusercontent.com/37681/47664751-f5ac8b00-db5c-11e8-849a-1dbeaa818252.png)





