### PR TITLE
Allow externally allocated buffers

### DIFF
--- a/cppsrc/U8g2lib.h
+++ b/cppsrc/U8g2lib.h
@@ -166,6 +166,7 @@ class U8G2 : public Print
     uint8_t nextPage(void) { return u8g2_NextPage(&u8g2); }
     
     uint8_t *getBufferPtr(void) { return u8g2_GetBufferPtr(&u8g2); }
+    void setBufferPtr(uint8_t *buf) { u8g2_SetBufferPtr(&u8g2, buf); }
     uint8_t getBufferTileHeight(void) { return u8g2_GetBufferTileHeight(&u8g2); }
     uint8_t getBufferTileWidth(void) { return u8g2_GetBufferTileWidth(&u8g2); }
     uint8_t getPageCurrTileRow(void) { return u8g2_GetBufferCurrTileRow(&u8g2); }	// obsolete

--- a/csrc/u8g2.h
+++ b/csrc/u8g2.h
@@ -1070,6 +1070,8 @@ void u8g2_SetBufferCurrTileRow(u8g2_t *u8g2, uint8_t row) U8G2_NOINLINE;
 void u8g2_FirstPage(u8g2_t *u8g2);
 uint8_t u8g2_NextPage(u8g2_t *u8g2);
 
+void u8g2_SetBufferPtr(u8g2_t *u8g2, uint8_t *buf);
+
 #define u8g2_GetBufferPtr(u8g2) ((u8g2)->tile_buf_ptr)
 #define u8g2_GetBufferTileHeight(u8g2)	((u8g2)->tile_buf_height)
 #define u8g2_GetBufferTileWidth(u8g2)	(u8g2_GetU8x8(u8g2)->display_info->tile_width)

--- a/csrc/u8g2_buffer.c
+++ b/csrc/u8g2_buffer.c
@@ -37,6 +37,11 @@
 #include <string.h>
 
 /*============================================*/
+void u8g2_SetBufferPtr(u8g2_t *u8g2, uint8_t *buf) {
+  u8g2->tile_buf_ptr = buf;
+}
+
+/*============================================*/
 void u8g2_ClearBuffer(u8g2_t *u8g2)
 {
   size_t cnt;


### PR DESCRIPTION
Added support for library users to allocate their own buffer and ask the library to use this instead of the built-in statically allocated buffer. This allows users to optionally have a separate buffer per display.

Fixes #796 with the preferred solution discussed in this issue. 

Note: Because a new method has been added, you also need to update:
* `keywords.txt` in `U8g2_Arduino` repositiory
* wiki docs