### PR TITLE
Added dynamic display buffer allocation capability

### DIFF
--- a/cppsrc/U8g2lib.h
+++ b/cppsrc/U8g2lib.h
@@ -132,7 +132,15 @@ class U8G2 : public Print
     
     bool begin(void) {
       /* note: call to u8x8_utf8_init is not required here, this is done in the setup procedures before */
-      initDisplay(); clearDisplay(); setPowerSave(0); return 1;}
+      #ifndef U8G2_USE_DYNAMIC_ALLOC
+      initDisplay(); 
+      clearDisplay(); 
+      setPowerSave(0); 
+      return 1;
+      #else
+      return 0;
+      #endif
+    }
 
     void beginSimple(void) {
       /* does not clear the display and does not wake up the display */

--- a/cppsrc/U8g2lib.h
+++ b/cppsrc/U8g2lib.h
@@ -171,6 +171,10 @@ class U8G2 : public Print
     void firstPage(void) { u8g2_FirstPage(&u8g2); }
     uint8_t nextPage(void) { return u8g2_NextPage(&u8g2); }
     
+    #ifdef U8G2_USE_DYNAMIC_ALLOC
+    void setBufferPtr(uint8_t *buf) { u8g2_SetBufferPtr(&u8g2, buf); }
+    uint16_t getBufferSize() { u8g2_GetBufferSize(&u8g2); }
+    #endif
     uint8_t *getBufferPtr(void) { return u8g2_GetBufferPtr(&u8g2); }
     uint8_t getBufferTileHeight(void) { return u8g2_GetBufferTileHeight(&u8g2); }
     uint8_t getBufferTileWidth(void) { return u8g2_GetBufferTileWidth(&u8g2); }

--- a/csrc/u8g2.h
+++ b/csrc/u8g2.h
@@ -60,6 +60,13 @@
 
 #include "u8x8.h"
 
+/*
+  The following macro switches the library into dynamic display buffer allocation mode.
+  Defining this constant will disable all static memory allocation for device memory buffer and thus allows the user to allocate device buffers statically.
+  Before using any display functions, the dynamic buffer *must* be assigned to the u8g2 struct using the u8g2_SetBufferPtr function.
+  When using dynamic allocation, the stack size must be increased by u8g2_GetBufferSize bytes.
+ */
+//#define U8G2_USE_DYNAMIC_ALLOC
 
 /*
   The following macro enables 16 Bit mode. 
@@ -277,7 +284,7 @@ struct u8g2_struct
   const u8g2_cb_t *cb;		/* callback drawprocedures, can be replaced for rotation */
   
   /* the following variables must be assigned during u8g2 setup */
-  uint8_t *tile_buf_ptr;	/* ptr to memory area with u8g2.display_info->tile_width * 8 * tile_buf_height bytes */
+  uint8_t *tile_buf_ptr;	/* ptr to memory area with u8x8.display_info->tile_width * 8 * tile_buf_height bytes */
   uint8_t tile_buf_height;	/* height of the tile memory area in tile rows */
   uint8_t tile_curr_row;	/* current row for picture loop */
   
@@ -1134,6 +1141,10 @@ void u8g2_SetBufferCurrTileRow(u8g2_t *u8g2, uint8_t row) U8G2_NOINLINE;
 void u8g2_FirstPage(u8g2_t *u8g2);
 uint8_t u8g2_NextPage(u8g2_t *u8g2);
 
+#ifdef U8G2_USE_DYNAMIC_ALLOC
+#define u8g2_SetBufferPtr(u8g2, buf) ((u8g2)->tile_buf_ptr = buf);
+#define u8g2_GetBufferSize(u8g2) ((u8g2)->u8x8.display_info->tile_width * 8 * (u8g2)->tile_buf_height)
+#endif
 #define u8g2_GetBufferPtr(u8g2) ((u8g2)->tile_buf_ptr)
 #define u8g2_GetBufferTileHeight(u8g2)	((u8g2)->tile_buf_height)
 #define u8g2_GetBufferTileWidth(u8g2)	(u8g2_GetU8x8(u8g2)->display_info->tile_width)

--- a/csrc/u8g2.h
+++ b/csrc/u8g2.h
@@ -1142,7 +1142,7 @@ void u8g2_FirstPage(u8g2_t *u8g2);
 uint8_t u8g2_NextPage(u8g2_t *u8g2);
 
 #ifdef U8G2_USE_DYNAMIC_ALLOC
-#define u8g2_SetBufferPtr(u8g2, buf) ((u8g2)->tile_buf_ptr = buf);
+#define u8g2_SetBufferPtr(u8g2, buf) ((u8g2)->tile_buf_ptr = (buf));
 #define u8g2_GetBufferSize(u8g2) ((u8g2)->u8x8.display_info->tile_width * 8 * (u8g2)->tile_buf_height)
 #endif
 #define u8g2_GetBufferPtr(u8g2) ((u8g2)->tile_buf_ptr)

--- a/csrc/u8g2_d_memory.c
+++ b/csrc/u8g2_d_memory.c
@@ -5,776 +5,1421 @@
 
 uint8_t *u8g2_m_16_4_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[128];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_16_4_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[256];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_16_4_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 4;
+  return 0;
+  #else
   static uint8_t buf[512];
   *page_cnt = 4;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_16_8_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[128];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_16_8_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[256];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_16_8_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 8;
+  return 0;
+  #else
   static uint8_t buf[1024];
   *page_cnt = 8;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_9_5_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[72];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_9_5_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[144];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_9_5_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 5;
+  return 0;
+  #else
   static uint8_t buf[360];
   *page_cnt = 5;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_8_4_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[64];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_8_4_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[128];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_8_4_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 4;
+  return 0;
+  #else
   static uint8_t buf[256];
   *page_cnt = 4;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_8_16_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[64];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_8_16_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[128];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_8_16_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 16;
+  return 0;
+  #else
   static uint8_t buf[1024];
   *page_cnt = 16;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_12_12_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[96];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_12_12_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[192];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_12_12_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 12;
+  return 0;
+  #else
   static uint8_t buf[1152];
   *page_cnt = 12;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_16_16_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[128];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_16_16_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[256];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_16_16_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 16;
+  return 0;
+  #else
   static uint8_t buf[2048];
   *page_cnt = 16;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_20_20_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[160];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_20_20_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[320];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_20_20_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 20;
+  return 0;
+  #else
   static uint8_t buf[3200];
   *page_cnt = 20;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_32_8_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[256];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_32_8_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[512];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_32_8_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 8;
+  return 0;
+  #else
   static uint8_t buf[2048];
   *page_cnt = 8;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_8_6_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[64];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_8_6_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[128];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_8_6_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 6;
+  return 0;
+  #else
   static uint8_t buf[384];
   *page_cnt = 6;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_6_8_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[48];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_6_8_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[96];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_6_8_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 8;
+  return 0;
+  #else
   static uint8_t buf[384];
   *page_cnt = 8;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_12_2_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[96];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_12_2_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[192];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_12_2_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[192];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_16_12_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[128];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_16_12_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[256];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_16_12_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 12;
+  return 0;
+  #else
   static uint8_t buf[1536];
   *page_cnt = 12;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_32_4_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[256];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_32_4_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[512];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_32_4_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 4;
+  return 0;
+  #else
   static uint8_t buf[1024];
   *page_cnt = 4;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_24_4_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[192];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_24_4_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[384];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_24_4_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 4;
+  return 0;
+  #else
   static uint8_t buf[768];
   *page_cnt = 4;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_50_30_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[400];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_50_30_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[800];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_50_30_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 30;
+  return 0;
+  #else
   static uint8_t buf[12000];
   *page_cnt = 30;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_18_21_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[144];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_18_21_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[288];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_18_21_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 21;
+  return 0;
+  #else
   static uint8_t buf[3024];
   *page_cnt = 21;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_13_8_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[104];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_13_8_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[208];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_13_8_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 8;
+  return 0;
+  #else
   static uint8_t buf[832];
   *page_cnt = 8;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_11_6_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[88];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_11_6_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[176];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_11_6_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 6;
+  return 0;
+  #else
   static uint8_t buf[528];
   *page_cnt = 6;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_12_9_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[96];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_12_9_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[192];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_12_9_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 9;
+  return 0;
+  #else
   static uint8_t buf[864];
   *page_cnt = 9;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_24_8_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[192];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_24_8_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[384];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_24_8_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 8;
+  return 0;
+  #else
   static uint8_t buf[1536];
   *page_cnt = 8;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_30_8_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[240];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_30_8_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[480];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_30_8_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 8;
+  return 0;
+  #else
   static uint8_t buf[1920];
   *page_cnt = 8;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_30_15_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[240];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_30_15_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[480];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_30_15_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 15;
+  return 0;
+  #else
   static uint8_t buf[3600];
   *page_cnt = 15;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_30_16_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[240];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_30_16_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[480];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_30_16_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 16;
+  return 0;
+  #else
   static uint8_t buf[3840];
   *page_cnt = 16;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_20_16_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[160];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_20_16_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[320];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_20_16_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 16;
+  return 0;
+  #else
   static uint8_t buf[2560];
   *page_cnt = 16;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_20_13_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[160];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_20_13_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[320];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_20_13_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 13;
+  return 0;
+  #else
   static uint8_t buf[2080];
   *page_cnt = 13;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_30_20_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[240];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_30_20_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[480];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_30_20_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 20;
+  return 0;
+  #else
   static uint8_t buf[4800];
   *page_cnt = 20;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_40_30_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[320];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_40_30_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[640];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_40_30_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 30;
+  return 0;
+  #else
   static uint8_t buf[9600];
   *page_cnt = 30;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_17_4_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[136];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_17_4_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[272];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_17_4_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 4;
+  return 0;
+  #else
   static uint8_t buf[544];
   *page_cnt = 4;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_17_8_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[136];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_17_8_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[272];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_17_8_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 8;
+  return 0;
+  #else
   static uint8_t buf[1088];
   *page_cnt = 8;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_48_17_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[384];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_48_17_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[768];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_48_17_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 17;
+  return 0;
+  #else
   static uint8_t buf[6528];
   *page_cnt = 17;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_32_16_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[256];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_32_16_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[512];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_32_16_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 16;
+  return 0;
+  #else
   static uint8_t buf[4096];
   *page_cnt = 16;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_32_20_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[256];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_32_20_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[512];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_32_20_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 20;
+  return 0;
+  #else
   static uint8_t buf[5120];
   *page_cnt = 20;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_22_13_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[176];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_22_13_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[352];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_22_13_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 13;
+  return 0;
+  #else
   static uint8_t buf[2288];
   *page_cnt = 13;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_24_12_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[192];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_24_12_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[384];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_24_12_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 12;
+  return 0;
+  #else
   static uint8_t buf[2304];
   *page_cnt = 12;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_20_10_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[160];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_20_10_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[320];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_20_10_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 10;
+  return 0;
+  #else
   static uint8_t buf[1600];
   *page_cnt = 10;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_22_9_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[176];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_22_9_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[352];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_22_9_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 9;
+  return 0;
+  #else
   static uint8_t buf[1584];
   *page_cnt = 9;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_25_25_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[200];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_25_25_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[400];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_25_25_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 25;
+  return 0;
+  #else
   static uint8_t buf[5000];
   *page_cnt = 25;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_37_16_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[296];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_37_16_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[592];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_37_16_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 16;
+  return 0;
+  #else
   static uint8_t buf[4736];
   *page_cnt = 16;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_8_1_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[64];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_8_1_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[128];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_8_1_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[64];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_4_1_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[32];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_4_1_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[64];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_4_1_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[32];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_1_1_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[8];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_1_1_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[16];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_1_1_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[8];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_48_30_1(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 1;
+  return 0;
+  #else
   static uint8_t buf[384];
   *page_cnt = 1;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_48_30_2(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 2;
+  return 0;
+  #else
   static uint8_t buf[768];
   *page_cnt = 2;
   return buf;
+  #endif
 }
 uint8_t *u8g2_m_48_30_f(uint8_t *page_cnt)
 {
+  #ifdef U8G2_USE_DYNAMIC_ALLOC
+  *page_cnt = 30;
+  return 0;
+  #else
   static uint8_t buf[11520];
   *page_cnt = 30;
   return buf;
+  #endif
 }
 /* end of generated code */

--- a/tools/codebuild/codebuild.c
+++ b/tools/codebuild/codebuild.c
@@ -1922,9 +1922,14 @@ void do_controller_buffer_code(int idx, const char *postfix, int buf_len, int ro
     //FILE *fp = stdout;
     fprintf(buf_code_fp, "uint8_t *%s(uint8_t *page_cnt)\n", s);
     fprintf(buf_code_fp, "{\n");
+    fprintf(buf_code_fp, "  #ifdef U8G2_USE_DYNAMIC_ALLOC\n");
+    fprintf(buf_code_fp, "  *page_cnt = %d;\n", rows);
+    fprintf(buf_code_fp, "  return 0;\n");
+    fprintf(buf_code_fp, "  #else\n");
     fprintf(buf_code_fp, "  static uint8_t buf[%d];\n", buf_len);
     fprintf(buf_code_fp, "  *page_cnt = %d;\n", rows);
     fprintf(buf_code_fp, "  return buf;\n");
+    fprintf(buf_code_fp, "  #endif\n");
     fprintf(buf_code_fp, "}\n");
     
     fprintf(buf_header_fp, "uint8_t *%s(uint8_t *page_cnt);\n", s);
@@ -1980,7 +1985,7 @@ void do_md_display(int controller_idx, int display_idx)
 
     fprintf(fp, "| Controller \"%s\", ", controller_list[controller_idx].name);
     fprintf(fp, "Display \"%s\" | ", controller_list[controller_idx].display_list[display_idx].name);
-    fprintf(fp, "Descirption |\n");
+    fprintf(fp, "Description |\n");
     fprintf(fp, "|---|---|\n");
   }
   else


### PR DESCRIPTION
This pull request implements a very simple solution for allowing dynamic display buffer allocation for use with multiple displays. For this, codebuild.c was modified to generate a u8g2_d_memory.c file that disables static buffer allocation when the library is in dynamic allocation mode.

A few small changes were added to u8g2.h and U8g2lib.h to allow setting the buffer address and receiving the buffer size required for the current display setup.

During this, I discovered a small discrepancy between the code documentation of u8g2_struct and rewrote it to represent the actual state of implementation.