### PR TITLE
Custom page selection for paged display

### DIFF
--- a/cppsrc/U8g2lib.h
+++ b/cppsrc/U8g2lib.h
@@ -175,7 +175,8 @@ class U8G2 : public Print
     /* u8g2_buffer.c */
     void sendBuffer(void) { u8g2_SendBuffer(&u8g2); }
     void clearBuffer(void) { u8g2_ClearBuffer(&u8g2); }    
-    
+
+    uint8_t customPage(uint8_t page) { return u8g2_CustomPage(&u8g2, page); }
     void firstPage(void) { u8g2_FirstPage(&u8g2); }
     uint8_t nextPage(void) { return u8g2_NextPage(&u8g2); }
     

--- a/csrc/u8g2.h
+++ b/csrc/u8g2.h
@@ -1144,6 +1144,7 @@ void u8g2_ClearBuffer(u8g2_t *u8g2);
 
 void u8g2_SetBufferCurrTileRow(u8g2_t *u8g2, uint8_t row) U8G2_NOINLINE;
 
+uint8_t u8g2_CustomPage(u8g2_t * const u8g2, uint8_t const page);
 void u8g2_FirstPage(u8g2_t *u8g2);
 uint8_t u8g2_NextPage(u8g2_t *u8g2);
 

--- a/csrc/u8g2_buffer.c
+++ b/csrc/u8g2_buffer.c
@@ -104,6 +104,29 @@ void u8g2_SetBufferCurrTileRow(u8g2_t *u8g2, uint8_t row)
   u8g2->cb->update_page_win(u8g2);
 }
 
+uint8_t u8g2_PageFirstRow(u8g2_t const * const u8g2, uint8_t const page)
+{
+  return u8g2->tile_buf_height * page;
+}
+
+uint8_t u8g2_CustomPage(u8g2_t * const u8g2, uint8_t const page)
+{
+  uint8_t const row = u8g2_PageFirstRow(u8g2, page);
+  if ( row >= u8g2_GetU8x8(u8g2)->display_info->tile_height )
+  {
+    return 0;
+  }
+  else
+  {
+    if ( u8g2->is_auto_page_clear )
+    {
+      u8g2_ClearBuffer(u8g2);
+    }
+    u8g2_SetBufferCurrTileRow(u8g2, row);
+    return 1;
+  }
+}
+
 void u8g2_FirstPage(u8g2_t *u8g2)
 {
   if ( u8g2->is_auto_page_clear )

--- a/csrc/u8g2_buffer.c
+++ b/csrc/u8g2_buffer.c
@@ -104,11 +104,15 @@ void u8g2_SetBufferCurrTileRow(u8g2_t *u8g2, uint8_t row)
   u8g2->cb->update_page_win(u8g2);
 }
 
+/* Calculates the first row of the specified page - does not detect overflows
+ * or pages out of scope for the current display. */
 uint8_t u8g2_PageFirstRow(u8g2_t const * const u8g2, uint8_t const page)
 {
   return u8g2->tile_buf_height * page;
 }
 
+/* Sets the current buffer to the page specified.
+ * Returns 0 in case the page is invalid - otherwise 1. */
 uint8_t u8g2_CustomPage(u8g2_t * const u8g2, uint8_t const page)
 {
   uint8_t const row = u8g2_PageFirstRow(u8g2, page);
@@ -127,6 +131,7 @@ uint8_t u8g2_CustomPage(u8g2_t * const u8g2, uint8_t const page)
   }
 }
 
+/* Specialization [faster!] for setting the current buffer to the first page. */
 void u8g2_FirstPage(u8g2_t *u8g2)
 {
   if ( u8g2->is_auto_page_clear )
@@ -136,6 +141,8 @@ void u8g2_FirstPage(u8g2_t *u8g2)
   u8g2_SetBufferCurrTileRow(u8g2, 0);
 }
 
+/* Sends the current buffer to the display and attempts to set the buffer to the next page.
+ * Returns 0 in case the next page is invalid - otherwise 1 */
 uint8_t u8g2_NextPage(u8g2_t *u8g2)
 {
   uint8_t row;

--- a/csrc/u8g2_buffer.c
+++ b/csrc/u8g2_buffer.c
@@ -112,7 +112,7 @@ uint8_t u8g2_PageFirstRow(u8g2_t const * const u8g2, uint8_t const page)
 uint8_t u8g2_CustomPage(u8g2_t * const u8g2, uint8_t const page)
 {
   uint8_t const row = u8g2_PageFirstRow(u8g2, page);
-  if ( row >= u8g2_GetU8x8(u8g2)->display_info->tile_height )
+  if ( row > ( u8g2_GetU8x8(u8g2)->display_info->tile_height - u8g2->tile_buf_height ) )
   {
     return 0;
   }


### PR DESCRIPTION
I am currently using an SSD1306 128x64 display and trying to write to it using an Arduino Uno. Because 2kB of Ram and 1kB of image data leave too little for the rest of the functionality, I was happy to see, that this library enabled one to use a paged update approach.
As to further minimize the computational cost [as I am effectively trying to simulate an LCD Keypad Shield [16x2 Symbols]] and to be able to seperate updates of different parts of the display, I would like to select only a partial region of the display.
This is my proposal how to implement it - feedback and criticism is very welcome.