### PR TITLE
add ARDUINO_ARCH_STM32 to take benfit of Wire.begin(sda,scl) configuration

### DIFF
--- a/cppsrc/U8x8lib.cpp
+++ b/cppsrc/U8x8lib.cpp
@@ -1144,7 +1144,7 @@ extern "C" uint8_t u8x8_byte_arduino_hw_i2c(U8X8_UNUSED u8x8_t *u8x8, U8X8_UNUSE
     case U8X8_MSG_BYTE_INIT:
       if ( u8x8->bus_clock == 0 ) 	/* issue 769 */
 	u8x8->bus_clock = u8x8->display_info->i2c_bus_clock_100kHz * 100000UL;
-#if defined(ESP8266) || defined(ARDUINO_ARCH_ESP8266) || defined(ESP_PLATFORM) || defined(ARDUINO_ARCH_ESP32)
+#if defined(ESP8266) || defined(ARDUINO_ARCH_ESP8266) || defined(ESP_PLATFORM) || defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_STM32)
       /* for ESP8266/ESP32, Wire.begin has two more arguments: clock and data */          
       if ( u8x8->pins[U8X8_PIN_I2C_CLOCK] != U8X8_PIN_NONE && u8x8->pins[U8X8_PIN_I2C_DATA] != U8X8_PIN_NONE )
       {


### PR DESCRIPTION
STM32 controllers have several I2C peripherals. So user could choose one of them by selcting the right SDA/SCL.
