### PR TITLE
DrawFrame: Draw corners just once, fixes XOR mode.

### DIFF
--- a/csrc/u8g2_box.c
+++ b/csrc/u8g2_box.c
@@ -57,8 +57,6 @@ void u8g2_DrawBox(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, u8g2_uint_t w, u8g
 /*
   draw a frame (empty box)
   restriction: does not work for w = 0 or h = 0
-  ToDo:
-    pixel in the corners are drawn twice. This could be optimized.
 */
 void u8g2_DrawFrame(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, u8g2_uint_t w, u8g2_uint_t h)
 {
@@ -70,13 +68,18 @@ void u8g2_DrawFrame(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, u8g2_uint_t w, u
 #endif /* U8G2_WITH_INTERSECTION */
   
   u8g2_DrawHVLine(u8g2, x, y, w, 0);
-  u8g2_DrawHVLine(u8g2, x, y, h, 1);
-  x+=w;
-  x--;
-  u8g2_DrawHVLine(u8g2, x, y, h, 1);
-  y+=h;
-  y--;
-  u8g2_DrawHVLine(u8g2, xtmp, y, w, 0);
+  if (h >= 2) {
+    h-=2;
+    y++;
+    if (h > 0) {
+      u8g2_DrawHVLine(u8g2, x, y, h, 1);
+      x+=w;
+      x--;
+      u8g2_DrawHVLine(u8g2, x, y, h, 1);
+      y+=h;
+    }
+    u8g2_DrawHVLine(u8g2, xtmp, y, w, 0);
+  }
 }
 
 


### PR DESCRIPTION
Hello.

I noticed that with XOR mode i.e. `setDrawColor(2)`, `drawFrame()` does not draw the corners.
This pull request fixes the ToDo there :-)

Cheers.
