### PR TITLE
Set clock polarity in software SPI implementations

### DIFF
--- a/cppsrc/U8x8lib.cpp
+++ b/cppsrc/U8x8lib.cpp
@@ -392,6 +392,7 @@ extern "C" uint8_t u8x8_byte_arduino_4wire_sw_spi(u8x8_t *u8x8, uint8_t msg, uin
   uint8_t i, b;
   uint8_t *data;
   uint8_t takeover_edge = u8x8_GetSPIClockPhase(u8x8);
+  uint8_t clock_polarity = u8x8_GetSPIClockPolarity(u8x8);
   //uint8_t not_takeover_edge = 1 - takeover_edge;
 
   /* the following static vars are recalculated in U8X8_MSG_BYTE_START_TRANSFER */
@@ -431,6 +432,9 @@ extern "C" uint8_t u8x8_byte_arduino_4wire_sw_spi(u8x8_t *u8x8, uint8_t msg, uin
 	      *arduino_clock_port |= arduino_clock_mask;	    
 	      *arduino_clock_port &= arduino_clock_n_mask;
 	    }
+	    if (clock_polarity == 1) {
+	      *arduino_clock_port |= arduino_clock_mask;
+	    }
 	  }
 	  else
 #endif
@@ -445,6 +449,9 @@ extern "C" uint8_t u8x8_byte_arduino_4wire_sw_spi(u8x8_t *u8x8, uint8_t msg, uin
 	      *arduino_clock_port |= arduino_clock_mask;	    
 	      b <<= 1;
 	      *arduino_clock_port &= arduino_clock_n_mask;
+	    }
+	    if (clock_polarity == 1) {
+	      *arduino_clock_port |= arduino_clock_mask;
 	    }
 	  }
 	  SREG = SREG_backup;
@@ -468,6 +475,9 @@ extern "C" uint8_t u8x8_byte_arduino_4wire_sw_spi(u8x8_t *u8x8, uint8_t msg, uin
 	      *arduino_clock_port &= arduino_clock_n_mask;
 	      *arduino_clock_port |= arduino_clock_mask;	    
 	    }
+	    if (clock_polarity == 1) {
+	      *arduino_clock_port |= arduino_clock_mask;
+	    }
 	  }
 	  else
 #endif
@@ -482,6 +492,9 @@ extern "C" uint8_t u8x8_byte_arduino_4wire_sw_spi(u8x8_t *u8x8, uint8_t msg, uin
 	      *arduino_clock_port &= arduino_clock_n_mask;
 	      b <<= 1;
 	      *arduino_clock_port |= arduino_clock_mask;	    
+	    }
+	    if (clock_polarity == 1) {
+	      *arduino_clock_port |= arduino_clock_mask;
 	    }
 	  }
 	  SREG = SREG_backup;
@@ -517,6 +530,10 @@ extern "C" uint8_t u8x8_byte_arduino_4wire_sw_spi(u8x8_t *u8x8, uint8_t msg, uin
       arduino_data_port = portOutputRegister(digitalPinToPort(u8x8->pins[U8X8_PIN_SPI_DATA]));
       arduino_data_mask = digitalPinToBitMask(u8x8->pins[U8X8_PIN_SPI_DATA]);
       arduino_data_n_mask = ~arduino_data_mask;
+
+      if (clock_polarity == 1) {
+        *arduino_clock_port |= arduino_clock_mask;
+      }
       
       break;
     case U8X8_MSG_BYTE_END_TRANSFER:


### PR DESCRIPTION
Set the clock polarity in software SPI implementations; previously CPOL was always 0.

I have only implemented this as a PoC for Arduino 4 wire software SPI so far, since I am not sure if I understand the differing implementations well enough and lack the required test setups; so please take this with a grain of salt.