### PR TITLE
Added scroll and rotate to font glyphs

### DIFF
--- a/cppsrc/U8g2lib.h
+++ b/cppsrc/U8g2lib.h
@@ -251,6 +251,7 @@ class U8G2 : public Print
     void setFont(const uint8_t  *font) {u8g2_SetFont(&u8g2, font); }
     void setFontMode(uint8_t  is_transparent) {u8g2_SetFontMode(&u8g2, is_transparent); }
     void setFontDirection(uint8_t dir) {u8g2_SetFontDirection(&u8g2, dir); }
+    void setFontScroll(int8_t x, int8_t y, uint8_t gap=0) {u8g2_SetFontScroll(&u8g2, x, y, gap); }
 
     int8_t getAscent(void) { return u8g2_GetAscent(&u8g2); }
     int8_t getDescent(void) { return u8g2_GetDescent(&u8g2); }

--- a/csrc/u8g2.h
+++ b/csrc/u8g2.h
@@ -117,6 +117,13 @@
 #define U8G2_WITH_FONT_ROTATION
 
 /*
+  The following macro enables scrolling for glyphs.
+  
+  Sept 2020: Disabling this macro will save up to ??? bytes on AVR 
+*/
+#define U8G2_WITH_FONT_SCROLLING
+
+/*
   U8glib V2 contains support for unicode plane 0 (Basic Multilingual Plane, BMP).
   The following macro activates this support. Deactivation would save some ROM.
   This definition also defines the behavior of the expected string encoding.
@@ -242,7 +249,15 @@ struct _u8g2_font_decode_t
   
   u8g2_uint_t target_x;
   u8g2_uint_t target_y;
-  
+#ifdef U8G2_WITH_FONT_SCROLLING
+  int8_t target_x_offset;
+  int8_t target_y_offset;
+  int8_t target_delta;
+  int8_t scroll_x;
+  int8_t scroll_y;
+  uint8_t gap; /* gap in pixel scrolling rotation */
+#endif
+
   int8_t x;						/* local coordinates, (0,0) is upper left */
   int8_t y;
   int8_t glyph_width;	
@@ -1335,6 +1350,7 @@ u8g2_uint_t u8g2_DrawGlyph(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, uint16_t 
 int8_t u8g2_GetStrX(u8g2_t *u8g2, const char *s);	/* for u8g compatibility */
 
 void u8g2_SetFontDirection(u8g2_t *u8g2, uint8_t dir);
+void u8g2_SetFontScroll(u8g2_t *u8g2, int8_t x, int8_t y, uint8_t gap);
 u8g2_uint_t u8g2_DrawStr(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, const char *str);
 u8g2_uint_t u8g2_DrawUTF8(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, const char *str);
 u8g2_uint_t u8g2_DrawExtendedUTF8(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, uint8_t to_left, u8g2_kerning_t *kerning, const char *str);

--- a/csrc/u8g2_font.c
+++ b/csrc/u8g2_font.c
@@ -404,7 +404,25 @@ void u8g2_font_decode_len(u8g2_t *u8g2, uint8_t len, uint8_t is_foreground)
   /* get the local position */
   lx = decode->x;
   ly = decode->y;
-  
+
+#ifdef U8G2_WITH_FONT_SCROLLING
+  u8g2_int_t sx,sy;
+  uint8_t sh = decode->gap; /*scroll gap*/
+  uint8_t sw = sh;
+  uint8_t srem;
+  sh += u8g2->font_ref_ascent;
+  sh -= u8g2->font_ref_descent; /*scroll box height=current font (all character) used height+scroll gap*/
+  sw += decode->target_delta; /*scroll box width=current font (per character) used width+scroll gap*/
+  ly += u8g2->font_ref_ascent;
+  ly -= decode->glyph_height;
+  ly -= decode->target_y_offset; /*offset so zero points to top edge of glyph*/
+  sy = decode->scroll_y;
+  if( (sy!=0)&&(sh!=0) ){
+    sy %= sh; /*scroll inbounds*/
+    if(ly<-sy) /*(sy+ly<0)*/
+      sy += sh; /*bring point up into scroll box*/
+  }
+#endif
   for(;;)
   {
     /* calculate the number of pixel to the right edge of the glyph */
@@ -417,14 +435,40 @@ void u8g2_font_decode_len(u8g2_t *u8g2, uint8_t len, uint8_t is_foreground)
     if ( cnt < rem )
       current = cnt;
     
-    
     /* now draw the line, but apply the rotation around the glyph target position */
     //u8g2_font_decode_draw_pixel(u8g2, lx,ly,current, is_foreground);
 
     /* get target position */
     x = decode->target_x;
     y = decode->target_y;
-
+#ifdef U8G2_WITH_FONT_SCROLLING
+    /* apply scrolling */
+    sx = decode->scroll_x;
+    lx += decode->target_x_offset; /*offset so zero points to right edge of glyph*/
+    if( (sx!=0)&&(sw!=0) ){
+      sx %= sw; /*scroll inbounds*/
+      if(lx<-sx){ /*(sx+lx<0)*/
+        sx += sw; /*bring point up into scroll box*/
+      }else if( (sx+lx)>=sw )
+        sx -= sw; /*bring point down into scroll box*/
+    }
+    lx +=sx; /*x position within scroll box*/
+    srem = sw;
+    srem -= lx; /*pixels to right of scroll box*/
+    if(current<=srem)
+      srem = 0; /*all draw line within scroll area*/
+    /* otherwise srem = pixels to edge */
+    if(lx > decode->target_delta){
+      current = 0; /*start of line beyond right edge of font box*/
+    }else if((lx+current) > decode->target_delta){
+      current = decode->target_delta; /*shorten end of draw line to right edge of font box*/
+      current -= lx;
+    }
+    if( (sy>0)&&(sh!=0) )
+      if( (sy+ly)>=sh )
+        sy -= sh; /*bring point down into scroll box*/
+    ly +=sy; /*y position within scroll box*/
+#endif
     /* apply rotation */
 #ifdef U8G2_WITH_FONT_ROTATION
     
@@ -438,6 +482,9 @@ void u8g2_font_decode_len(u8g2_t *u8g2, uint8_t len, uint8_t is_foreground)
     y += ly;
 #endif
     
+#ifdef U8G2_WITH_FONT_SCROLLING
+    if( (ly < (u8g2->font_ref_ascent - u8g2->font_ref_descent)) && (lx < decode->target_delta) ){ /*dont draw if outside viewable font box*/
+#endif
     /* draw foreground and background (if required) */
     if ( is_foreground )
     {
@@ -467,16 +514,33 @@ void u8g2_font_decode_len(u8g2_t *u8g2, uint8_t len, uint8_t is_foreground)
 #endif
       );   
     }
-    
+#ifdef U8G2_WITH_FONT_SCROLLING
+    }
+    lx -=sx;
+    lx -= decode->target_x_offset; /*remove offset, restores back to zero points to left edge of font box*/
+    ly -=sy; /*restore*/
+    if(srem==0){  /*line drawn complet or to glyph right edge*/
+#endif
     /* check, whether the end of the run length code has been reached */
     if ( cnt < rem )
       break;
     cnt -= rem;
     lx = 0;
-    ly++;
+    ly++; 
+#ifdef U8G2_WITH_FONT_SCROLLING
+      /*reached scroll box right edge, still more to draw*/
+      cnt -= srem;
+      lx += srem;
+    }
+#endif
   }
   lx += cnt;
   
+#ifdef U8G2_WITH_FONT_SCROLLING
+    ly -= u8g2->font_ref_ascent;
+    ly += decode->glyph_height;
+    ly += decode->target_y_offset; /*remove offset, restores back to zero points to ascent top edge of font box*/
+#endif
   decode->x = lx;
   decode->y = ly;
   
@@ -533,6 +597,20 @@ int8_t u8g2_font_decode_glyph(u8g2_t *u8g2, const uint8_t *glyph_data)
   
   if ( decode->glyph_width > 0 )
   {
+#ifdef U8G2_WITH_FONT_SCROLLING
+    decode->target_x_offset = x;
+    decode->target_y_offset = y;
+    decode->target_delta = d;
+ #ifdef U8G2_WITH_FONT_ROTATION /*point to top left of font ascent box*/
+    decode->target_x = u8g2_add_vector_x(decode->target_x, 0, -u8g2->font_ref_ascent, decode->dir);
+    decode->target_y = u8g2_add_vector_y(decode->target_y, 0, -u8g2->font_ref_ascent, decode->dir);
+    //u8g2_add_vector(&(decode->target_x), &(decode->target_y), 0, -u8g2->font_ref_ascent, decode->dir);
+
+ #else
+//    decode->target_x += 0;
+    decode->target_y -= u8g2->font_ref_ascent;
+ #endif
+#else
 #ifdef U8G2_WITH_FONT_ROTATION
     decode->target_x = u8g2_add_vector_x(decode->target_x, x, -(h+y), decode->dir);
     decode->target_y = u8g2_add_vector_y(decode->target_y, x, -(h+y), decode->dir);
@@ -542,6 +620,7 @@ int8_t u8g2_font_decode_glyph(u8g2_t *u8g2, const uint8_t *glyph_data)
 #else
     decode->target_x += x;
     decode->target_y -= h+y;
+#endif
 #endif
     //u8g2_add_vector(&(decode->target_x), &(decode->target_y), x, -(h+y), decode->dir);
 
@@ -1288,4 +1367,11 @@ void u8g2_SetFontDirection(u8g2_t *u8g2, uint8_t dir)
 #endif
 }
 
-
+void u8g2_SetFontScroll(u8g2_t *u8g2, int8_t x, int8_t y, uint8_t gap)
+{
+#ifdef U8G2_WITH_FONT_SCROLLING  
+  u8g2->font_decode.scroll_x = x;
+  u8g2->font_decode.scroll_y = y;
+  u8g2->font_decode.gap = gap;
+#endif
+}

--- a/csrc/u8g2_setup.c
+++ b/csrc/u8g2_setup.c
@@ -101,6 +101,12 @@ void u8g2_SetupBuffer(u8g2_t *u8g2, uint8_t *buf, uint8_t tile_buf_height, u8g2_
 #ifdef U8G2_WITH_FONT_ROTATION  
   u8g2->font_decode.dir = 0;
 #endif
+
+#ifdef U8G2_WITH_FONT_SCROLLING  
+  u8g2->font_decode.scroll_x = 0;
+  u8g2->font_decode.scroll_y = 0;
+  u8g2->font_decode.gap = 0;  
+#endif
 }
 
 /*


### PR DESCRIPTION
Add animation effect to fonts glyph. Can scroll/rotate glyphs, left, right(x), up and down(y) within fonts viewable area(fonts acsent to descent height and its delta width)
Added a gap option, zero means no gap, so scroll looks like glyph is rotating or sliding. Gap value greater than fonts viewable area makes glyph scroll out it.

void setFontScroll(int8_t x, int8_t y, uint8_t gap=0)

I used this to make a 'V' into an animated chevron >> status icon. This feature scrolls relative to glyph, so changes with rotate direction