### PR TITLE
treewide: Fix address mode setup on SSD1306-like displays

### DIFF
--- a/csrc/u8x8_d_sh1106_64x32.c
+++ b/csrc/u8x8_d_sh1106_64x32.c
@@ -51,7 +51,7 @@ static const uint8_t u8x8_d_sh1106_64x32_init_seq[] = {
   U8X8_C(0x040),		                /* set display start line to 0, 0.42 OLED */
   U8X8_CA(0xad, 0x8b),      	 	/* DC-DC ON/OFF Mode Set: Built-in DC-DC is used, Normal Display (POR = 0x8b) */
   U8X8_C(0x33),				/* set charge pump voltage 0x30 (POR) .. 0x33 */
-  U8X8_CA(0x020, 0x000),		/* page addressing mode */
+  U8X8_CA(0x020, 0x002),		/* page addressing mode */
   
   U8X8_C(0x0a1),				/* segment remap a0/a1, 0.66 OLED  */
   U8X8_C(0x0c8),				/* c0: scan dir normal, c8: reverse, 0.66 OLED  */

--- a/csrc/u8x8_d_sh1106_72x40.c
+++ b/csrc/u8x8_d_sh1106_72x40.c
@@ -51,7 +51,7 @@ static const uint8_t u8x8_d_sh1106_72x40_init_seq[] = {
   U8X8_C(0x040),		                /* set display start line to 0, 0.42 OLED */
   U8X8_CA(0xad, 0x8b),      	 	/* DC-DC ON/OFF Mode Set: Built-in DC-DC is used, Normal Display (POR = 0x8b) */
   U8X8_C(0x33),				/* set charge pump voltage 0x30 (POR) .. 0x33 */
-  U8X8_CA(0x020, 0x000),		/* page addressing mode */
+  U8X8_CA(0x020, 0x002),		/* page addressing mode */
   
   U8X8_C(0x0a1),				/* segment remap a0/a1, 0.66 OLED  */
   U8X8_C(0x0c8),				/* c0: scan dir normal, c8: reverse, 0.66 OLED  */

--- a/csrc/u8x8_d_sh1107.c
+++ b/csrc/u8x8_d_sh1107.c
@@ -246,7 +246,7 @@ static const uint8_t u8x8_d_sh1107_seeed_96x96_init_seq[] = {
   //U8X8_CA(0x0a8, 0x03f),		/* multiplex ratio */
   U8X8_CA(0x0d3, 0x000),		/* display offset */
   U8X8_CA(0x0dc, 0x000),		/* start line */
-  //U8X8_CA(0x020, 0x000),		/* page addressing mode */
+  //U8X8_CA(0x020, 0x002),		/* page addressing mode */
   
   U8X8_C(0x0a1),				/* segment remap a0/a1*/
   U8X8_C(0x0c8),				/* c0: scan dir normal, c8: reverse */

--- a/csrc/u8x8_d_ssd1305.c
+++ b/csrc/u8x8_d_ssd1305.c
@@ -166,7 +166,7 @@ static const uint8_t u8x8_d_ssd1305_128x32_noname_init_seq[] = {
   U8X8_CA(0x0a8, 0x03f),		/* multiplex ratio */
   U8X8_CA(0x0d3, 32),			/* display offset to 32 */
   U8X8_C(0x040),		        	/* set display start line to 0 */
-  U8X8_CA(0x020, 0x000),		/* page addressing mode */
+  U8X8_CA(0x020, 0x002),		/* page addressing mode */
   
   U8X8_C(0x0a1),				/* segment remap a0/a1*/
   U8X8_C(0x0c8),				/* c0: scan dir normal, c8: reverse */
@@ -329,7 +329,7 @@ static const uint8_t u8x8_d_ssd1305_128x64_adafruit_init_seq[] = {
   U8X8_CA(0x0a8, 0x03f),		/* multiplex ratio */
   U8X8_CA(0x0d3, 0x040),		/* display offset to 32 */
   U8X8_C(0x040),		        	/* set display start line to 0 */
-  U8X8_CA(0x020, 0x000),		/* page addressing mode */
+  U8X8_CA(0x020, 0x002),		/* page addressing mode */
   
   U8X8_C(0x0a1),				/* segment remap a0/a1*/
   U8X8_C(0x0c8),				/* c0: scan dir normal, c8: reverse */

--- a/csrc/u8x8_d_ssd1306_128x32.c
+++ b/csrc/u8x8_d_ssd1306_128x32.c
@@ -50,7 +50,7 @@ static const uint8_t u8x8_d_ssd1306_128x32_univision_init_seq[] = {
   U8X8_CA(0x0d3, 0x000),		/* display offset */
   U8X8_C(0x040),		                /* set display start line to 0 */
   U8X8_CA(0x08d, 0x014),		/* [2] charge pump setting (p62): 0x014 enable, 0x010 disable */
-  U8X8_CA(0x020, 0x000),		/* page addressing mode */
+  U8X8_CA(0x020, 0x002),		/* page addressing mode */
   
   U8X8_C(0x0a1),				/* segment remap a0/a1*/
   U8X8_C(0x0c8),				/* c0: scan dir normal, c8: reverse */

--- a/csrc/u8x8_d_ssd1306_128x64_noname.c
+++ b/csrc/u8x8_d_ssd1306_128x64_noname.c
@@ -50,7 +50,7 @@ static const uint8_t u8x8_d_ssd1306_128x64_noname_init_seq[] = {
   U8X8_CA(0x0d3, 0x000),		/* display offset */
   U8X8_C(0x040),		                /* set display start line to 0 */
   U8X8_CA(0x08d, 0x014),		/* [2] charge pump setting (p62): 0x014 enable, 0x010 disable, SSD1306 only, should be removed for SH1106 */
-  U8X8_CA(0x020, 0x000),		/* page addressing mode */
+  U8X8_CA(0x020, 0x002),		/* page addressing mode */
   
   U8X8_C(0x0a1),				/* segment remap a0/a1*/
   U8X8_C(0x0c8),				/* c0: scan dir normal, c8: reverse */
@@ -87,7 +87,7 @@ static const uint8_t u8x8_d_ssd1306_128x64_vcomh0_init_seq[] = {
   U8X8_CA(0x0d3, 0x000),		/* display offset */
   U8X8_C(0x040),		                /* set display start line to 0 */
   U8X8_CA(0x08d, 0x014),		/* [2] charge pump setting (p62): 0x014 enable, 0x010 disable */
-  U8X8_CA(0x020, 0x000),		/* page addressing mode */
+  U8X8_CA(0x020, 0x002),		/* page addressing mode */
   
   U8X8_C(0x0a1),				/* segment remap a0/a1*/
   U8X8_C(0x0c8),				/* c0: scan dir normal, c8: reverse */
@@ -123,7 +123,7 @@ static const uint8_t u8x8_d_ssd1306_128x64_alt0_init_seq[] = {
   U8X8_CA(0x0d3, 0x000),		/* display offset */
   U8X8_C(0x040),		                /* set display start line to 0 */
   U8X8_CA(0x08d, 0x014),		/* [2] charge pump setting (p62): 0x014 enable, 0x010 disable, SSD1306 only, should be removed for SH1106 */
-  U8X8_CA(0x020, 0x000),		/* page addressing mode */
+  U8X8_CA(0x020, 0x002),		/* page addressing mode */
   
   U8X8_C(0x0a1),				/* segment remap a0/a1*/
   U8X8_C(0x0c8),				/* c0: scan dir normal, c8: reverse */

--- a/csrc/u8x8_d_ssd1306_2040x16.c
+++ b/csrc/u8x8_d_ssd1306_2040x16.c
@@ -50,7 +50,7 @@ U8X8_START_TRANSFER(), /* enable chip, delay is part of the transfer start */
     /// according to the datasheet, 0x00 is NOT page addressing mode, but horizontal addressing mode;
     /// so it looks like u8g2 expects horizontal addressing (and the inline comment is wrong) while the Winstar example
     /// actually uses page addressing (which is the reset default)
-    U8X8_CA(0x020, 0x000), /* page addressing mode */
+    U8X8_CA(0x020, 0x002), /* page addressing mode */
 
     U8X8_C(0x0a1), /* segment remap a0/a1, 0.71 OLED  */
     U8X8_C(0x0c8), /* c0: scan dir normal, c8: reverse, 0.71 OLED  */

--- a/csrc/u8x8_d_ssd1306_48x64.c
+++ b/csrc/u8x8_d_ssd1306_48x64.c
@@ -50,7 +50,7 @@ U8X8_START_TRANSFER(), /* enable chip, delay is part of the transfer start */
     /// according to the datasheet, 0x00 is NOT page addressing mode, but horizontal addressing mode;
     /// so it looks like u8g2 expects horizontal addressing (and the inline comment is wrong) while the Winstar example
     /// actually uses page addressing (which is the reset default)
-    U8X8_CA(0x020, 0x000), /* page addressing mode */
+    U8X8_CA(0x020, 0x002), /* page addressing mode */
 
     U8X8_C(0x0a1), /* segment remap a0/a1, 0.71 OLED  */
     U8X8_C(0x0c8), /* c0: scan dir normal, c8: reverse, 0.71 OLED  */

--- a/csrc/u8x8_d_ssd1306_64x32.c
+++ b/csrc/u8x8_d_ssd1306_64x32.c
@@ -174,7 +174,7 @@ static const uint8_t u8x8_d_ssd1306_64x32_noname_init_seq[] = {
   U8X8_CA(0x0d3, 0x000),		/* display offset */
   U8X8_C(0x040),		                /* set display start line to 0 */
   U8X8_CA(0x08d, 0x014),		/* [2] charge pump setting (p62): 0x014 enable, 0x010 disable */
-  U8X8_CA(0x020, 0x000),		/* page addressing mode */
+  U8X8_CA(0x020, 0x002),		/* page addressing mode */
   
   U8X8_C(0x0a1),				/* segment remap a0/a1 */
   U8X8_C(0x0c8),				/* c0: scan dir normal, c8: reverse */
@@ -223,7 +223,7 @@ static const uint8_t u8x8_d_ssd1306_64x32_1f_init_seq[] = {
   U8X8_CA(0x0d3, 0x000),		/* display offset */
   U8X8_C(0x040),		                /* set display start line to 0 */
   U8X8_CA(0x08d, 0x014),		/* [2] charge pump setting (p62): 0x014 enable, 0x010 disable */
-  U8X8_CA(0x020, 0x000),		/* page addressing mode */
+  U8X8_CA(0x020, 0x002),		/* page addressing mode */
   
   U8X8_C(0x0a1),				/* segment remap a0/a1 */
   U8X8_C(0x0c8),				/* c0: scan dir normal, c8: reverse */

--- a/csrc/u8x8_d_ssd1306_64x48.c
+++ b/csrc/u8x8_d_ssd1306_64x48.c
@@ -50,7 +50,7 @@ static const uint8_t u8x8_d_ssd1306_64x48_er_init_seq[] = {
   U8X8_CA(0x0d3, 0x000),		/* display offset, 0.66 OLED  */
   U8X8_C(0x040),		                /* set display start line to 0, 0.66 OLED */
   U8X8_CA(0x08d, 0x014),		/* [2] charge pump setting (p62): 0x014 enable, 0x010 disable, 0.66 OLED  0x14*/
-  U8X8_CA(0x020, 0x000),		/* page addressing mode */
+  U8X8_CA(0x020, 0x002),		/* page addressing mode */
   
   U8X8_C(0x0a1),				/* segment remap a0/a1, 0.66 OLED  */
   U8X8_C(0x0c8),				/* c0: scan dir normal, c8: reverse, 0.66 OLED  */

--- a/csrc/u8x8_d_ssd1306_72x40.c
+++ b/csrc/u8x8_d_ssd1306_72x40.c
@@ -102,7 +102,7 @@ static const uint8_t u8x8_d_ssd1306_72x40_er_init_seq[] = {
   U8X8_C(0x0a6),				/* none inverted normal display mode */
   U8X8_C(0x0a4),				/* output ram to display */
   
-  U8X8_CA(0x020, 0x000),		/* page addressing mode */
+  U8X8_CA(0x020, 0x002),		/* page addressing mode */
   
   U8X8_C(0x0a1),				/* segment remap a0/a1, 0.66 OLED  */
   U8X8_C(0x0c8),				/* c0: scan dir normal, c8: reverse, 0.66 OLED  */

--- a/csrc/u8x8_d_ssd1306_96x16.c
+++ b/csrc/u8x8_d_ssd1306_96x16.c
@@ -50,7 +50,7 @@ static const uint8_t u8x8_d_ssd1306_96x16_er_init_seq[] = {
   U8X8_CA(0x0d3, 0x000),		/* display offset, 0.69 OLED  */
   U8X8_C(0x040),		                /* set display start line to 0, 0.69 OLED */
   U8X8_CA(0x08d, 0x014),		/* [2] charge pump setting (p62): 0x014 enable, 0x010 disable, 0.66 OLED  0x14*/
-  U8X8_CA(0x020, 0x000),		/* page addressing mode */
+  U8X8_CA(0x020, 0x002),		/* page addressing mode */
   
   U8X8_C(0x0a1),				/* segment remap a0/a1, 0.66 OLED  */
   U8X8_C(0x0c8),				/* c0: scan dir normal, c8: reverse, 0.66 OLED  */

--- a/csrc/u8x8_d_ssd1316.c
+++ b/csrc/u8x8_d_ssd1316.c
@@ -173,7 +173,7 @@ static const uint8_t u8x8_d_ssd1316_128x32_init_seq[] = {
   U8X8_CA(0x08d, 0x015),		/* [2] charge pump setting (p62): 0x014 enable, 0x010 disable, */
   
   //U8X8_CA(0x0a2, 0x000),		/* set display start line to 0 */
-  //U8X8_CA(0x020, 0x000),		/* page addressing mode */
+  //U8X8_CA(0x020, 0x002),		/* page addressing mode */
   
   
   // Flipmode

--- a/csrc/u8x8_d_ssd1317.c
+++ b/csrc/u8x8_d_ssd1317.c
@@ -55,7 +55,7 @@ static const uint8_t u8x8_d_ssd1317_96x96_init_seq[] = {
   U8X8_CA(0x0d3, 0x000),		/* display offset */
   U8X8_CA(0x0a2, 0x000),		/* set display start line to 0 */
   U8X8_CA(0x08d, 0x014),		/* [2] charge pump setting (p62): 0x014 enable, 0x010 disable, SSD1306 only, should be removed for SH1106 */
-  U8X8_CA(0x020, 0x000),		/* page addressing mode */
+  U8X8_CA(0x020, 0x002),		/* page addressing mode */
   
   U8X8_C(0x0a0),			/* segment remap a0/a1*/
   U8X8_C(0x0c8),			/* c0: scan dir normal, c8: reverse */

--- a/csrc/u8x8_d_ssd1318.c
+++ b/csrc/u8x8_d_ssd1318.c
@@ -82,7 +82,7 @@ static const uint8_t u8x8_d_ssd1318_128x96_icp_init_seq[] = {
   U8X8_CA(0x0db, 0x030), 		/* vcomh deselect level, value from issue 784 example code  */  
   
   
-  //U8X8_CA(0x020, 0x000),		/* page addressing mode */
+  //U8X8_CA(0x020, 0x002),		/* page addressing mode */
   //U8X8_C(0x02e),				/* Deactivate scroll */ 
   
   U8X8_C(0x0a4),				/* output ram to display */
@@ -127,7 +127,7 @@ static const uint8_t u8x8_d_ssd1318_128x96_xcp_init_seq[] = {
   U8X8_CA(0x0db, 0x030), 		/* vcomh deselect level, value from issue 784 example code  */  
   
   
-  //U8X8_CA(0x020, 0x000),		/* page addressing mode */
+  //U8X8_CA(0x020, 0x002),		/* page addressing mode */
   //U8X8_C(0x02e),				/* Deactivate scroll */ 
   
   U8X8_C(0x0a4),				/* output ram to display */

--- a/sys/arm/stm32l031x6/eval_board/u8x8/u8x8_d_ssd1305.c
+++ b/sys/arm/stm32l031x6/eval_board/u8x8/u8x8_d_ssd1305.c
@@ -166,7 +166,7 @@ static const uint8_t u8x8_d_ssd1305_128x32_noname_init_seq[] = {
   U8X8_CA(0x0a8, 0x03f),		/* multiplex ratio */
   U8X8_CA(0x0d3, 32),			/* display offset to 32 */
   U8X8_C(0x040),		        	/* set display start line to 0 */
-  U8X8_CA(0x020, 0x000),		/* page addressing mode */
+  U8X8_CA(0x020, 0x002),		/* page addressing mode */
   
   U8X8_C(0x0a1),				/* segment remap a0/a1*/
   U8X8_C(0x0c8),				/* c0: scan dir normal, c8: reverse */

--- a/sys/arm/stm32l031x6/eval_board/u8x8/u8x8_d_ssd1306_128x32.c
+++ b/sys/arm/stm32l031x6/eval_board/u8x8/u8x8_d_ssd1306_128x32.c
@@ -50,7 +50,7 @@ static const uint8_t u8x8_d_ssd1306_128x32_univision_init_seq[] = {
   U8X8_CA(0x0d3, 0x000),		/* display offset */
   U8X8_C(0x040),		                /* set display start line to 0 */
   U8X8_CA(0x08d, 0x014),		/* [2] charge pump setting (p62): 0x014 enable, 0x010 disable */
-  U8X8_CA(0x020, 0x000),		/* page addressing mode */
+  U8X8_CA(0x020, 0x002),		/* page addressing mode */
   
   U8X8_C(0x0a1),				/* segment remap a0/a1*/
   U8X8_C(0x0c8),				/* c0: scan dir normal, c8: reverse */

--- a/sys/arm/stm32l031x6/eval_board/u8x8/u8x8_d_ssd1306_128x64_noname.c
+++ b/sys/arm/stm32l031x6/eval_board/u8x8/u8x8_d_ssd1306_128x64_noname.c
@@ -50,7 +50,7 @@ static const uint8_t u8x8_d_ssd1306_128x64_noname_init_seq[] = {
   U8X8_CA(0x0d3, 0x000),		/* display offset */
   U8X8_C(0x040),		                /* set display start line to 0 */
   U8X8_CA(0x08d, 0x014),		/* [2] charge pump setting (p62): 0x014 enable, 0x010 disable, SSD1306 only, should be removed for SH1106 */
-  U8X8_CA(0x020, 0x000),		/* page addressing mode */
+  U8X8_CA(0x020, 0x002),		/* page addressing mode */
   
   U8X8_C(0x0a1),				/* segment remap a0/a1*/
   U8X8_C(0x0c8),				/* c0: scan dir normal, c8: reverse */
@@ -87,7 +87,7 @@ static const uint8_t u8x8_d_ssd1306_128x64_vcomh0_init_seq[] = {
   U8X8_CA(0x0d3, 0x000),		/* display offset */
   U8X8_C(0x040),		                /* set display start line to 0 */
   U8X8_CA(0x08d, 0x014),		/* [2] charge pump setting (p62): 0x014 enable, 0x010 disable */
-  U8X8_CA(0x020, 0x000),		/* page addressing mode */
+  U8X8_CA(0x020, 0x002),		/* page addressing mode */
   
   U8X8_C(0x0a1),				/* segment remap a0/a1*/
   U8X8_C(0x0c8),				/* c0: scan dir normal, c8: reverse */
@@ -123,7 +123,7 @@ static const uint8_t u8x8_d_ssd1306_128x64_alt0_init_seq[] = {
   U8X8_CA(0x0d3, 0x000),		/* display offset */
   U8X8_C(0x040),		                /* set display start line to 0 */
   U8X8_CA(0x08d, 0x014),		/* [2] charge pump setting (p62): 0x014 enable, 0x010 disable, SSD1306 only, should be removed for SH1106 */
-  U8X8_CA(0x020, 0x000),		/* page addressing mode */
+  U8X8_CA(0x020, 0x002),		/* page addressing mode */
   
   U8X8_C(0x0a1),				/* segment remap a0/a1*/
   U8X8_C(0x0c8),				/* c0: scan dir normal, c8: reverse */

--- a/sys/arm/stm32l031x6/eval_board/u8x8/u8x8_d_ssd1306_64x32.c
+++ b/sys/arm/stm32l031x6/eval_board/u8x8/u8x8_d_ssd1306_64x32.c
@@ -174,7 +174,7 @@ static const uint8_t u8x8_d_ssd1306_64x32_noname_init_seq[] = {
   U8X8_CA(0x0d3, 0x000),		/* display offset */
   U8X8_C(0x040),		                /* set display start line to 0 */
   U8X8_CA(0x08d, 0x014),		/* [2] charge pump setting (p62): 0x014 enable, 0x010 disable */
-  U8X8_CA(0x020, 0x000),		/* page addressing mode */
+  U8X8_CA(0x020, 0x002),		/* page addressing mode */
   
   U8X8_C(0x0a1),				/* segment remap a0/a1 */
   U8X8_C(0x0c8),				/* c0: scan dir normal, c8: reverse */
@@ -223,7 +223,7 @@ static const uint8_t u8x8_d_ssd1306_64x32_1f_init_seq[] = {
   U8X8_CA(0x0d3, 0x000),		/* display offset */
   U8X8_C(0x040),		                /* set display start line to 0 */
   U8X8_CA(0x08d, 0x014),		/* [2] charge pump setting (p62): 0x014 enable, 0x010 disable */
-  U8X8_CA(0x020, 0x000),		/* page addressing mode */
+  U8X8_CA(0x020, 0x002),		/* page addressing mode */
   
   U8X8_C(0x0a1),				/* segment remap a0/a1 */
   U8X8_C(0x0c8),				/* c0: scan dir normal, c8: reverse */

--- a/sys/arm/stm32l031x6/eval_board/u8x8/u8x8_d_ssd1306_64x48.c
+++ b/sys/arm/stm32l031x6/eval_board/u8x8/u8x8_d_ssd1306_64x48.c
@@ -50,7 +50,7 @@ static const uint8_t u8x8_d_ssd1306_64x48_er_init_seq[] = {
   U8X8_CA(0x0d3, 0x000),		/* display offset, 0.66 OLED  */
   U8X8_C(0x040),		                /* set display start line to 0, 0.66 OLED */
   U8X8_CA(0x08d, 0x014),		/* [2] charge pump setting (p62): 0x014 enable, 0x010 disable, 0.66 OLED  0x14*/
-  U8X8_CA(0x020, 0x000),		/* page addressing mode */
+  U8X8_CA(0x020, 0x002),		/* page addressing mode */
   
   U8X8_C(0x0a1),				/* segment remap a0/a1, 0.66 OLED  */
   U8X8_C(0x0c8),				/* c0: scan dir normal, c8: reverse, 0.66 OLED  */

--- a/sys/arm/stm32l031x6/eval_board/u8x8/u8x8_d_ssd1306_96x16.c
+++ b/sys/arm/stm32l031x6/eval_board/u8x8/u8x8_d_ssd1306_96x16.c
@@ -50,7 +50,7 @@ static const uint8_t u8x8_d_ssd1306_96x16_er_init_seq[] = {
   U8X8_CA(0x0d3, 0x000),		/* display offset, 0.69 OLED  */
   U8X8_C(0x040),		                /* set display start line to 0, 0.69 OLED */
   U8X8_CA(0x08d, 0x014),		/* [2] charge pump setting (p62): 0x014 enable, 0x010 disable, 0.66 OLED  0x14*/
-  U8X8_CA(0x020, 0x000),		/* page addressing mode */
+  U8X8_CA(0x020, 0x002),		/* page addressing mode */
   
   U8X8_C(0x0a1),				/* segment remap a0/a1, 0.66 OLED  */
   U8X8_C(0x0c8),				/* c0: scan dir normal, c8: reverse, 0.66 OLED  */


### PR DESCRIPTION
Previously the addressing mode was set as 0x00. However, it was intended
to be page addressing mode which is 0x02. By accident the overflow behaviour
of horizontal addressing mode matches the algorithm u8g2 uses to update the
display, thus it still worked.
This commit changes all SSD1306-like displays to be actually setup in page
addressing mode.