### PR TITLE
Added ability to invert Menu Event button logic

### DIFF
--- a/cppsrc/U8g2lib.h
+++ b/cppsrc/U8g2lib.h
@@ -102,6 +102,8 @@ class U8G2 : public Print
       u8g2_SetMenuDownPin(&u8g2, val); }
     void setMenuHomePin(uint8_t val) {
       u8g2_SetMenuHomePin(&u8g2, val); }
+    void setMenuLogic(uint8_t val) {
+        u8g2_SetMenuLogic(&u8g2, val); }
 #endif
 
     /* return 0 for no event or U8X8_MSG_GPIO_MENU_SELECT, */
@@ -149,13 +151,14 @@ class U8G2 : public Print
       
 #ifdef U8X8_USE_PINS 
     /* use U8X8_PIN_NONE if a pin is not required */
-    bool begin(uint8_t menu_select_pin, uint8_t menu_next_pin, uint8_t menu_prev_pin, uint8_t menu_up_pin = U8X8_PIN_NONE, uint8_t menu_down_pin = U8X8_PIN_NONE, uint8_t menu_home_pin = U8X8_PIN_NONE) {
+    bool begin(uint8_t menu_select_pin, uint8_t menu_next_pin, uint8_t menu_prev_pin, uint8_t menu_up_pin = U8X8_PIN_NONE, uint8_t menu_down_pin = U8X8_PIN_NONE, uint8_t menu_home_pin = U8X8_PIN_NONE, uint8_t is_logic_inverted = 0) {
       setMenuSelectPin(menu_select_pin);
       setMenuNextPin(menu_next_pin);
       setMenuPrevPin(menu_prev_pin);
       setMenuUpPin(menu_up_pin);
       setMenuDownPin(menu_down_pin);
       setMenuHomePin(menu_home_pin);
+      setMenuLogic(is_logic_inverted);
       return begin(); }
 #endif
 

--- a/cppsrc/U8x8lib.cpp
+++ b/cppsrc/U8x8lib.cpp
@@ -157,7 +157,14 @@ extern "C" uint8_t u8x8_gpio_and_delay_arduino(u8x8_t *u8x8, uint8_t msg, uint8_
 	      // call yield() for the first pin only, u8x8 will always request all the pins, so this should be ok
 	      yield();
 	    }
-	    u8x8_SetGPIOResult(u8x8, digitalRead(i) == 0 ? 0 : 1);
+        if (u8x8->is_logic_inverted)
+        {
+            u8x8_SetGPIOResult(u8x8, digitalRead(i) == 0 ? 1 : 0);
+        }
+        else
+        {
+            u8x8_SetGPIOResult(u8x8, digitalRead(i) == 0 ? 0 : 1);
+        }
 	  }
 	}
 	break;

--- a/cppsrc/U8x8lib.h
+++ b/cppsrc/U8x8lib.h
@@ -206,6 +206,8 @@ class U8X8 : public Print
       u8x8_SetMenuDownPin(&u8x8, val); }
     void setMenuHomePin(uint8_t val) {
       u8x8_SetMenuHomePin(&u8x8, val); }
+    void setMenuLogic(uint8_t val) {
+        u8x8_SetMenuLogic(&u8x8, val); }
 #endif
       
     void initDisplay(void) {
@@ -225,13 +227,14 @@ class U8X8 : public Print
 
 #ifdef U8X8_USE_PINS 
     /* use U8X8_PIN_NONE if a pin is not required */
-    bool begin(uint8_t menu_select_pin, uint8_t menu_next_pin, uint8_t menu_prev_pin, uint8_t menu_up_pin = U8X8_PIN_NONE, uint8_t menu_down_pin = U8X8_PIN_NONE, uint8_t menu_home_pin = U8X8_PIN_NONE) {
+    bool begin(uint8_t menu_select_pin, uint8_t menu_next_pin, uint8_t menu_prev_pin, uint8_t menu_up_pin = U8X8_PIN_NONE, uint8_t menu_down_pin = U8X8_PIN_NONE, uint8_t menu_home_pin = U8X8_PIN_NONE, uint8_t is_logic_inverted = 0) {
       setMenuSelectPin(menu_select_pin);
       setMenuNextPin(menu_next_pin);
       setMenuPrevPin(menu_prev_pin);
       setMenuUpPin(menu_up_pin);
       setMenuDownPin(menu_down_pin);
       setMenuHomePin(menu_home_pin);
+      setMenuLogic(is_logic_inverted);
       return begin(); }
 #endif
       

--- a/csrc/u8g2.h
+++ b/csrc/u8g2.h
@@ -399,6 +399,7 @@ void u8g2_ClearDisplay(u8g2_t *u8g2);
 #define u8g2_SetMenuHomePin(u8g2, val) u8x8_SetMenuHomePin(u8g2_GetU8x8(u8g2), (val))
 #define u8g2_SetMenuUpPin(u8g2, val) u8x8_SetMenuUpPin(u8g2_GetU8x8(u8g2), (val))
 #define u8g2_SetMenuDownPin(u8g2, val) u8x8_SetMenuDownPin(u8g2_GetU8x8(u8g2), (val))
+#define u8g2_SetMenuLogic(u8g2, val) u8x8_SetMenuLogic(u8g2_GetU8x8(u8g2), (val))
 #endif
 
 /*==========================================*/

--- a/csrc/u8x8.h
+++ b/csrc/u8x8.h
@@ -342,6 +342,7 @@ struct u8x8_struct
   uint8_t i2c_started;	/* for i2c interface */
   //uint8_t device_address;	/* OBSOLETE???? - this is the device address, replacement for U8X8_MSG_CAD_SET_DEVICE */
   uint8_t utf8_state;		/* number of chars which are still to scan */
+  uint8_t is_logic_inverted;    /*determines weather or not to invert the logic on MENU button events*/
   uint8_t gpio_result;	/* return value from the gpio call (only for MENU keys at the moment) */ 
   uint8_t debounce_default_pin_state;
   uint8_t debounce_last_pin_state;
@@ -382,6 +383,7 @@ struct u8x8_struct
 #define u8x8_SetMenuHomePin(u8x8, val) u8x8_SetPin((u8x8),U8X8_PIN_MENU_HOME,(val))
 #define u8x8_SetMenuUpPin(u8x8, val) u8x8_SetPin((u8x8),U8X8_PIN_MENU_UP,(val))
 #define u8x8_SetMenuDownPin(u8x8, val) u8x8_SetPin((u8x8),U8X8_PIN_MENU_DOWN,(val))
+#define u8x8_SetMenuLogic(u8x8, val) (u8x8)->is_logic_inverted = (val)
 #endif
 
 


### PR DESCRIPTION
This is a small enhancement providing the user the ability to invert the logic of buttons used with menu events. This is helpful when a button is active HIGH rather than active LOW like the library currently supports. A simple bool to toggle inverted logic was added to the 'begin()' method when 'U8X8_USE_PINS' is defined.