### PR TITLE
Add RT-Thread RTOS support

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -1,0 +1,19 @@
+from building import *
+import rtconfig
+
+# get current directory
+cwd     = GetCurrentDir()
+# The set of source files associated with this SConscript file.
+src     = Glob('csrc/*.c')
+src    += Glob('sys/rt-thread/port/*.c')
+src    += Glob('sys/rt-thread/examples/*.c')
+
+path    = [cwd + '/']
+path   += [cwd + '/csrc']
+path   += [cwd + '/sys/rt-thread/port']
+
+LOCAL_CCFLAGS = ''
+
+group = DefineGroup('u8g2s', src, depend = [''], CPPPATH = path, LOCAL_CCFLAGS = LOCAL_CCFLAGS)
+
+Return('group')

--- a/SConscript
+++ b/SConscript
@@ -14,6 +14,6 @@ path   += [cwd + '/sys/rt-thread/port']
 
 LOCAL_CCFLAGS = ''
 
-group = DefineGroup('u8g2s', src, depend = [''], CPPPATH = path, LOCAL_CCFLAGS = LOCAL_CCFLAGS)
+group = DefineGroup('u8g2s', src, depend = [''], CPPPATH = path, LOCAL_CCFLAGS = LOCAL_CCFLAGS, CPPDEFINES=['RTT_U8G2'])
 
 Return('group')

--- a/csrc/u8x8.h
+++ b/csrc/u8x8.h
@@ -188,6 +188,8 @@ uint8_t u8x8_pgm_read_esp(const uint8_t * addr);   /* u8x8_8x8.c */
 #define U8X8_USE_PINS
 #endif
 
+#define U8X8_USE_PINS
+
 /*==========================================*/
 /* U8X8 typedefs and data structures */
 

--- a/csrc/u8x8.h
+++ b/csrc/u8x8.h
@@ -188,7 +188,9 @@ uint8_t u8x8_pgm_read_esp(const uint8_t * addr);   /* u8x8_8x8.c */
 #define U8X8_USE_PINS
 #endif
 
+#ifdef RTT_U8G2
 #define U8X8_USE_PINS
+#endif
 
 /*==========================================*/
 /* U8X8 typedefs and data structures */

--- a/sys/rt-thread/examples/ssd1306_12864_4wire_hw_spi_example.c
+++ b/sys/rt-thread/examples/ssd1306_12864_4wire_hw_spi_example.c
@@ -1,0 +1,38 @@
+#include <rthw.h>
+#include <rtthread.h>
+#include <rtdevice.h>
+#include <board.h>
+#include <u8g2_port.h>
+
+// You may reference Drivers/drv_gpio.c for pinout
+// In u8x8.h #define U8X8_USE_PINS
+
+#define OLED_SPI_PIN_RES                    GET_PIN(A, 2)  // PA2
+#define OLED_SPI_PIN_DC                     GET_PIN(A, 1)  // PA1
+#define OLED_SPI_PIN_CS                     GET_PIN(A, 0)  // PA0
+
+static void ssd1306_12864_4wire_hw_spi_example(int argc,char *argv[])
+{
+    u8g2_t u8g2;
+
+    // Initialization
+    u8g2_Setup_ssd1306_128x64_noname_f( &u8g2, U8G2_R0, u8x8_byte_rt_4wire_hw_spi, u8x8_rt_gpio_and_delay);
+    u8x8_SetPin(u8g2_GetU8x8(&u8g2), U8X8_PIN_CS, OLED_SPI_PIN_CS);
+    u8x8_SetPin(u8g2_GetU8x8(&u8g2), U8X8_PIN_DC, OLED_SPI_PIN_DC);
+    u8x8_SetPin(u8g2_GetU8x8(&u8g2), U8X8_PIN_RESET, OLED_SPI_PIN_RES);
+
+        u8g2_InitDisplay(&u8g2);
+    u8g2_SetPowerSave(&u8g2, 0);
+
+    // Draw Graphics
+    /* full buffer example, setup procedure ends in _f */
+    u8g2_ClearBuffer(&u8g2);
+    u8g2_SetFont(&u8g2, u8g2_font_ncenB08_tr);
+    u8g2_DrawStr(&u8g2, 1, 18, "U8g2 on RT-Thread");
+    u8g2_SendBuffer(&u8g2);
+
+    u8g2_SetFont(&u8g2, u8g2_font_unifont_t_symbols);
+    u8g2_DrawGlyph(&u8g2, 112, 56, 0x2603 );
+    u8g2_SendBuffer(&u8g2);
+}
+MSH_CMD_EXPORT(ssd1306_12864_4wire_hw_spi_example, sw 4wire spi ssd1306 sample);

--- a/sys/rt-thread/examples/ssd1306_12864_4wire_sw_spi_example.c
+++ b/sys/rt-thread/examples/ssd1306_12864_4wire_sw_spi_example.c
@@ -1,0 +1,42 @@
+#include <rthw.h>
+#include <rtthread.h>
+#include <rtdevice.h>
+#include <board.h>
+#include <u8g2_port.h>
+
+// You may reference Drivers/drv_gpio.c for pinout
+// In u8x8.h #define U8X8_USE_PINS
+
+#define OLED_SPI_PIN_CLK                   GET_PIN(A, 5)  // PA5
+#define OLED_SPI_PIN_MOSI                  GET_PIN(A, 7)  // PA7
+#define OLED_SPI_PIN_RES                   GET_PIN(A, 2)  // PA2
+#define OLED_SPI_PIN_DC                    GET_PIN(A, 1)  // PA1
+#define OLED_SPI_PIN_CS                    GET_PIN(A, 0)  // PA0
+
+static void ssd1306_12864_4wire_sw_spi_example(int argc,char *argv[])
+{
+    u8g2_t u8g2;
+
+    // Initialization
+    u8g2_Setup_ssd1306_128x64_noname_f( &u8g2, U8G2_R0, u8x8_byte_4wire_sw_spi, u8x8_rt_gpio_and_delay);
+    u8x8_SetPin(u8g2_GetU8x8(&u8g2), U8X8_PIN_SPI_CLOCK, OLED_SPI_PIN_CLK);
+    u8x8_SetPin(u8g2_GetU8x8(&u8g2), U8X8_PIN_SPI_DATA, OLED_SPI_PIN_MOSI);
+    u8x8_SetPin(u8g2_GetU8x8(&u8g2), U8X8_PIN_CS, OLED_SPI_PIN_CS);
+    u8x8_SetPin(u8g2_GetU8x8(&u8g2), U8X8_PIN_DC, OLED_SPI_PIN_DC);
+    u8x8_SetPin(u8g2_GetU8x8(&u8g2), U8X8_PIN_RESET, OLED_SPI_PIN_RES);
+
+    u8g2_InitDisplay(&u8g2);
+    u8g2_SetPowerSave(&u8g2, 0);
+
+    // Draw Graphics
+    /* full buffer example, setup procedure ends in _f */
+    u8g2_ClearBuffer(&u8g2);
+    u8g2_SetFont(&u8g2, u8g2_font_ncenB08_tr);
+    u8g2_DrawStr(&u8g2, 1, 18, "U8g2 on RT-Thread");
+    u8g2_SendBuffer(&u8g2);
+
+    u8g2_SetFont(&u8g2, u8g2_font_unifont_t_symbols);
+    u8g2_DrawGlyph(&u8g2, 112, 56, 0x2603 );
+    u8g2_SendBuffer(&u8g2);
+}
+MSH_CMD_EXPORT(ssd1306_12864_4wire_sw_spi_example, sw 4wire spi ssd1306 sample);

--- a/sys/rt-thread/examples/ssd1306_12864_hw_i2c_example.c
+++ b/sys/rt-thread/examples/ssd1306_12864_hw_i2c_example.c
@@ -1,0 +1,26 @@
+#include <rthw.h>
+#include <rtthread.h>
+#include <rtdevice.h>
+#include <u8g2_port.h>
+
+static void ssd1306_12864_hw_i2c_example(int argc,char *argv[])
+{
+    u8g2_t u8g2;
+
+    // Initialization
+    u8g2_Setup_ssd1306_i2c_128x64_noname_f( &u8g2, U8G2_R0, u8x8_byte_rt_hw_i2c, u8x8_rt_gpio_and_delay);
+    u8g2_InitDisplay(&u8g2);
+    u8g2_SetPowerSave(&u8g2, 0);
+
+    /* full buffer example, setup procedure ends in _f */
+    u8g2_ClearBuffer(&u8g2);
+    u8g2_SetFont(&u8g2, u8g2_font_ncenB08_tr);
+    u8g2_DrawStr(&u8g2, 1, 18, "U8g2 on RT-Thread");
+    u8g2_SendBuffer(&u8g2);
+
+    // Draw Graphics
+    u8g2_SetFont(&u8g2, u8g2_font_unifont_t_symbols);
+    u8g2_DrawGlyph(&u8g2, 112, 56, 0x2603 );
+    u8g2_SendBuffer(&u8g2);
+}
+MSH_CMD_EXPORT(ssd1306_12864_hw_i2c_example, i2c ssd1306 sample);

--- a/sys/rt-thread/examples/ssd1306_12864_sw_i2c_example.c
+++ b/sys/rt-thread/examples/ssd1306_12864_sw_i2c_example.c
@@ -1,0 +1,33 @@
+#include <rthw.h>
+#include <rtthread.h>
+#include <rtdevice.h>
+#include <board.h>
+#include <u8g2_port.h>
+
+#define OLED_I2C_PIN_SCL                    GET_PIN(B, 6)  // PB6
+#define OLED_I2C_PIN_SDA                    GET_PIN(B, 7)  // PB7
+
+static void ssd1306_12864_sw_i2c_example(int argc,char *argv[])
+{
+    u8g2_t u8g2;
+
+    // Initialization
+    u8g2_Setup_ssd1306_i2c_128x64_noname_f( &u8g2, U8G2_R0, u8x8_byte_sw_i2c, u8x8_rt_gpio_and_delay);
+    u8x8_SetPin(u8g2_GetU8x8(&u8g2), U8X8_PIN_I2C_CLOCK, OLED_I2C_PIN_SCL);
+    u8x8_SetPin(u8g2_GetU8x8(&u8g2), U8X8_PIN_I2C_DATA, OLED_I2C_PIN_SDA);
+
+    u8g2_InitDisplay(&u8g2);
+    u8g2_SetPowerSave(&u8g2, 0);
+
+    // Draw Graphics
+    /* full buffer example, setup procedure ends in _f */
+    u8g2_ClearBuffer(&u8g2);
+    u8g2_SetFont(&u8g2, u8g2_font_ncenB08_tr);
+    u8g2_DrawStr(&u8g2, 1, 18, "U8g2 on RT-Thread");
+    u8g2_SendBuffer(&u8g2);
+
+    u8g2_SetFont(&u8g2, u8g2_font_unifont_t_symbols);
+    u8g2_DrawGlyph(&u8g2, 112, 56, 0x2603 );
+    u8g2_SendBuffer(&u8g2);
+}
+MSH_CMD_EXPORT(ssd1306_12864_sw_i2c_example, i2c ssd1306 software i2c sample);

--- a/sys/rt-thread/port/u8g2_port.c
+++ b/sys/rt-thread/port/u8g2_port.c
@@ -1,0 +1,325 @@
+#include "u8g2_port.h"
+#include <rtthread.h>
+#include <string.h>
+
+#define MAX_RETRY 3
+
+#if defined U8G2_USE_HW_I2C
+static struct rt_i2c_bus_device *i2c_bus = RT_NULL;
+#endif
+
+#if defined U8G2_USE_HW_SPI
+static struct rt_spi_device u8g2_spi_dev;
+
+int rt_hw_spi_config(uint8_t spi_mode, uint32_t max_hz, uint8_t cs_pin )
+{
+    rt_err_t res;
+
+    // Attach Device
+    rt_pin_mode(cs_pin, PIN_MODE_OUTPUT);
+    // spi cs signal will be controlled directly using gpio
+    if(u8g2_spi_dev.bus == RT_NULL)
+    {
+        res = rt_spi_bus_attach_device(&u8g2_spi_dev, U8G2_SPI_DEVICE_NAME, U8G2_SPI_BUS_NAME, RT_NULL);
+        if (res != RT_EOK)
+        {
+            rt_kprintf("[u8g2] Failed to attach device %s\n", U8G2_SPI_DEVICE_NAME);
+            return res;
+        }
+        else
+        {
+            rt_kprintf("[u8g2] Attach device to %s\n", U8G2_SPI_DEVICE_NAME);
+        }
+    }
+    else
+    {
+        rt_kprintf("[u8g2] Found device %s\n", U8G2_SPI_DEVICE_NAME);
+    }
+
+    // Set device SPI Mode
+    struct rt_spi_configuration cfg;
+    cfg.data_width = 8;
+    switch(spi_mode)
+    {
+        case 0: cfg.mode = RT_SPI_MASTER | RT_SPI_MODE_0 | RT_SPI_MSB; break;
+        case 1: cfg.mode = RT_SPI_MASTER | RT_SPI_MODE_1 | RT_SPI_MSB; break;
+        case 2: cfg.mode = RT_SPI_MASTER | RT_SPI_MODE_2 | RT_SPI_MSB; break;
+        case 3: cfg.mode = RT_SPI_MASTER | RT_SPI_MODE_3 | RT_SPI_MSB; break;
+    }
+    cfg.max_hz = max_hz; /* 20M,SPI max 42MHz,ssd1351 4-wire spi */
+    rt_spi_configure(&u8g2_spi_dev, &cfg);
+
+    return RT_EOK;
+}
+#endif /* U8G2_USE_HW_SPI */
+
+uint8_t u8x8_rt_gpio_and_delay(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr)
+{
+    switch(msg)
+    {
+        case U8X8_MSG_DELAY_NANO:            // delay arg_int * 1 nano second
+            __asm__ volatile("nop");
+            break;
+        
+        case U8X8_MSG_DELAY_100NANO:        // delay arg_int * 100 nano seconds
+            __asm__ volatile("nop");
+            break;
+        
+        case U8X8_MSG_DELAY_10MICRO:        // delay arg_int * 10 micro seconds
+            for (uint16_t n = 0; n < 320; n++)
+            {
+                __asm__ volatile("nop");
+            }
+        break;
+        
+        case U8X8_MSG_DELAY_MILLI:            // delay arg_int * 1 milli second
+            rt_thread_delay(arg_int);
+            break;
+        
+        case U8X8_MSG_GPIO_AND_DELAY_INIT:  
+            // Function which implements a delay, arg_int contains the amount of ms  
+            
+            // set spi pin mode 
+            rt_pin_mode(u8x8->pins[U8X8_PIN_SPI_CLOCK],PIN_MODE_OUTPUT);//d0 a5 15 d1 a7 17 res b0 18 dc b1 19 cs a4 14  
+            rt_pin_mode(u8x8->pins[U8X8_PIN_SPI_DATA],PIN_MODE_OUTPUT);
+            rt_pin_mode(u8x8->pins[U8X8_PIN_RESET],PIN_MODE_OUTPUT);
+            rt_pin_mode(u8x8->pins[U8X8_PIN_DC],PIN_MODE_OUTPUT);
+            rt_pin_mode(u8x8->pins[U8X8_PIN_CS],PIN_MODE_OUTPUT);
+            
+            // set i2c pin mode
+            rt_pin_mode(u8x8->pins[U8X8_PIN_I2C_DATA],PIN_MODE_OUTPUT);
+            rt_pin_mode(u8x8->pins[U8X8_PIN_I2C_CLOCK],PIN_MODE_OUTPUT);
+            
+            // set 8080 pin mode
+            rt_pin_mode(u8x8->pins[U8X8_PIN_D0],PIN_MODE_OUTPUT);
+            rt_pin_mode(u8x8->pins[U8X8_PIN_D1],PIN_MODE_OUTPUT);
+            rt_pin_mode(u8x8->pins[U8X8_PIN_D2],PIN_MODE_OUTPUT);
+            rt_pin_mode(u8x8->pins[U8X8_PIN_D3],PIN_MODE_OUTPUT);
+            rt_pin_mode(u8x8->pins[U8X8_PIN_D4],PIN_MODE_OUTPUT);
+            rt_pin_mode(u8x8->pins[U8X8_PIN_D5],PIN_MODE_OUTPUT);
+            rt_pin_mode(u8x8->pins[U8X8_PIN_D6],PIN_MODE_OUTPUT);
+            rt_pin_mode(u8x8->pins[U8X8_PIN_D7],PIN_MODE_OUTPUT);
+            rt_pin_mode(u8x8->pins[U8X8_PIN_E],PIN_MODE_OUTPUT);
+            rt_pin_mode(u8x8->pins[U8X8_PIN_DC],PIN_MODE_OUTPUT);
+            rt_pin_mode(u8x8->pins[U8X8_PIN_RESET],PIN_MODE_OUTPUT);
+            
+            // set value
+            rt_pin_write(u8x8->pins[U8X8_PIN_SPI_CLOCK],1);
+            rt_pin_write(u8x8->pins[U8X8_PIN_SPI_DATA],1);
+            rt_pin_write(u8x8->pins[U8X8_PIN_RESET],1);
+            rt_pin_write(u8x8->pins[U8X8_PIN_DC],1);
+            rt_pin_write(u8x8->pins[U8X8_PIN_CS],1);
+            break;
+        
+        case U8X8_MSG_DELAY_I2C:
+            // arg_int is the I2C speed in 100KHz, e.g. 4 = 400 KHz
+            // arg_int=1: delay by 5us, arg_int = 4: delay by 1.25us
+            for (uint16_t n = 0; n < (arg_int<=2?160:40); n++)
+            {
+                __asm__ volatile("nop");
+            }
+            break;
+
+        //case U8X8_MSG_GPIO_D0:                // D0 or SPI clock pin: Output level in arg_int
+        //case U8X8_MSG_GPIO_SPI_CLOCK:
+
+        //case U8X8_MSG_GPIO_D1:                // D1 or SPI data pin: Output level in arg_int
+        //case U8X8_MSG_GPIO_SPI_DATA:
+
+        case U8X8_MSG_GPIO_D2:                // D2 pin: Output level in arg_int
+            if (arg_int) rt_pin_write(u8x8->pins[U8X8_PIN_D2],1);  
+            else rt_pin_write(u8x8->pins[U8X8_PIN_D2],0);
+            break;
+
+        case U8X8_MSG_GPIO_D3:                // D3 pin: Output level in arg_int
+            if (arg_int) rt_pin_write(u8x8->pins[U8X8_PIN_D3],1);  
+            else rt_pin_write(u8x8->pins[U8X8_PIN_D3],0);
+            break;
+
+        case U8X8_MSG_GPIO_D4:                // D4 pin: Output level in arg_int
+            if (arg_int) rt_pin_write(u8x8->pins[U8X8_PIN_D4],1);  
+            else rt_pin_write(u8x8->pins[U8X8_PIN_D4],0);
+            break;
+
+        case U8X8_MSG_GPIO_D5:                // D5 pin: Output level in arg_int
+            if (arg_int) rt_pin_write(u8x8->pins[U8X8_PIN_D5],1);  
+            else rt_pin_write(u8x8->pins[U8X8_PIN_D5],0);
+            break;
+
+        case U8X8_MSG_GPIO_D6:                // D6 pin: Output level in arg_int
+            if (arg_int) rt_pin_write(u8x8->pins[U8X8_PIN_D6],1);  
+            else rt_pin_write(u8x8->pins[U8X8_PIN_D6],0);
+            break;
+
+        case U8X8_MSG_GPIO_D7:                // D7 pin: Output level in arg_int
+            if (arg_int) rt_pin_write(u8x8->pins[U8X8_PIN_D7],1);  
+            else rt_pin_write(u8x8->pins[U8X8_PIN_D7],0);
+            break;
+
+        case U8X8_MSG_GPIO_E:                // E/WR pin: Output level in arg_int
+            if (arg_int) rt_pin_write(u8x8->pins[U8X8_PIN_E],1);  
+            else rt_pin_write(u8x8->pins[U8X8_PIN_E],0);
+            break;
+
+        case U8X8_MSG_GPIO_I2C_CLOCK:
+            // arg_int=0: Output low at I2C clock pin
+            // arg_int=1: Input dir with pullup high for I2C clock pin
+            if (arg_int) rt_pin_write(u8x8->pins[U8X8_PIN_I2C_CLOCK],1);  
+            else rt_pin_write(u8x8->pins[U8X8_PIN_I2C_CLOCK],0);  
+            break;
+
+        case U8X8_MSG_GPIO_I2C_DATA:
+            // arg_int=0: Output low at I2C data pin
+            // arg_int=1: Input dir with pullup high for I2C data pin
+            if (arg_int) rt_pin_write(u8x8->pins[U8X8_PIN_I2C_DATA],1);  
+            else rt_pin_write(u8x8->pins[U8X8_PIN_I2C_DATA],0);              
+      break;
+
+        case U8X8_MSG_GPIO_SPI_CLOCK:  
+            //Function to define the logic level of the clockline  
+            if (arg_int) rt_pin_write(u8x8->pins[U8X8_PIN_SPI_CLOCK],1);  
+            else rt_pin_write(u8x8->pins[U8X8_PIN_SPI_CLOCK],0);
+            break;
+
+        case U8X8_MSG_GPIO_SPI_DATA:
+            //Function to define the logic level of the data line to the display  
+            if (arg_int) rt_pin_write(u8x8->pins[U8X8_PIN_SPI_DATA],1);  
+            else rt_pin_write(u8x8->pins[U8X8_PIN_SPI_DATA],0);  
+            break;
+
+        case U8X8_MSG_GPIO_CS:
+            // Function to define the logic level of the CS line  
+            if(arg_int)        rt_pin_write(u8x8->pins[U8X8_PIN_CS],1);
+            else        rt_pin_write(u8x8->pins[U8X8_PIN_CS],0);
+            break;
+
+        case U8X8_MSG_GPIO_DC:
+            //Function to define the logic level of the Data/ Command line  
+            if(arg_int) rt_pin_write(u8x8->pins[U8X8_PIN_DC],1);
+            else rt_pin_write(u8x8->pins[U8X8_PIN_DC],0);
+            break;
+
+        case U8X8_MSG_GPIO_RESET:
+            //Function to define the logic level of the RESET line
+            if (arg_int) rt_pin_write(u8x8->pins[U8X8_PIN_RESET],1);
+            else rt_pin_write(u8x8->pins[U8X8_PIN_RESET],0);
+            break;
+
+        default:
+            //A message was received which is not implemented, return 0 to indicate an error 
+            return 0; 
+    }
+    return 1;
+}
+
+#if defined U8G2_USE_HW_I2C
+uint8_t u8x8_byte_rt_hw_i2c(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr)
+{
+    /* u8g2/u8x8 will never send more than 32 bytes between START_TRANSFER and END_TRANSFER */
+    struct rt_i2c_msg msgs;
+    static uint8_t buffer[32];
+    static uint8_t buf_idx;
+    uint8_t *data;
+    
+    rt_uint8_t t = 0;
+    switch(msg)
+    {
+        case U8X8_MSG_BYTE_SEND:
+            data = (uint8_t *)arg_ptr;
+            while( arg_int > 0 )
+            {
+                buffer[buf_idx++] = *data;
+                data++;
+                arg_int--;
+            }
+            break;
+
+        case U8X8_MSG_BYTE_INIT:
+            i2c_bus = rt_i2c_bus_device_find(U8G2_I2C_DEVICE_NAME);
+            if (i2c_bus == RT_NULL)
+            {
+                rt_kprintf("[u8g2] Failed to find bus %s\n", U8G2_I2C_DEVICE_NAME);
+                return 0;
+            }
+            break;
+
+        case U8X8_MSG_BYTE_SET_DC:
+            break;
+
+        case U8X8_MSG_BYTE_START_TRANSFER:
+            buf_idx = 0;
+            break;
+
+        case U8X8_MSG_BYTE_END_TRANSFER:
+            if (i2c_bus == RT_NULL)
+            {
+                rt_kprintf("[u8g2] Failed to find bus %s\n", U8G2_I2C_DEVICE_NAME);
+                return 0;
+            }
+            // I2C Data Transfer
+            msgs.addr  = u8x8_GetI2CAddress(u8x8)>>1;
+            msgs.flags = RT_I2C_WR;
+            msgs.buf   = buffer;
+            msgs.len   = buf_idx;
+            while(rt_i2c_transfer(i2c_bus, &msgs, 1) != 1 && t < MAX_RETRY)
+            {
+                t++;
+            };
+            if(t >= MAX_RETRY)
+            {
+                return 0;
+            }
+            break;
+
+        default:
+            return 0;
+    }
+    return 1;
+}
+#endif /* U8G2_USE_HW_I2C */
+
+#if defined U8G2_USE_HW_SPI
+uint8_t u8x8_byte_rt_4wire_hw_spi(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr) {
+    struct rt_spi_message spi_msg;
+    switch(msg) 
+    {
+        case U8X8_MSG_BYTE_SEND:
+            spi_msg.send_buf   = arg_ptr;
+            spi_msg.recv_buf   = RT_NULL;
+            spi_msg.length     = arg_int;
+            spi_msg.cs_take    = 0;
+            spi_msg.cs_release = 0;
+            spi_msg.next       = RT_NULL;
+            rt_spi_transfer_message(&u8g2_spi_dev, &spi_msg);
+            break;
+
+        case U8X8_MSG_BYTE_INIT:
+            /* SPI mode has to be mapped to the mode of the current controller, at least Uno, Due, 101 have different SPI_MODEx values */
+            /*   0: clock active high, data out on falling edge, clock default value is zero, takover on rising edge */
+            /*   1: clock active high, data out on rising edge, clock default value is zero, takover on falling edge */
+            /*   2: clock active low, data out on rising edge */
+            /*   3: clock active low, data out on falling edge */
+            u8x8_gpio_SetCS(u8x8, u8x8->display_info->chip_disable_level);
+            rt_hw_spi_config(u8x8->display_info->spi_mode, u8x8->display_info->sck_clock_hz, u8x8->pins[U8X8_PIN_CS]);
+            break;
+
+        case U8X8_MSG_BYTE_SET_DC:
+            u8x8_gpio_SetDC(u8x8, arg_int);
+            break;
+
+        case U8X8_MSG_BYTE_START_TRANSFER:
+            u8x8_gpio_SetCS(u8x8, u8x8->display_info->chip_enable_level);
+            u8x8->gpio_and_delay_cb(u8x8, U8X8_MSG_DELAY_NANO, u8x8->display_info->post_chip_enable_wait_ns, NULL);
+            break;
+
+        case U8X8_MSG_BYTE_END_TRANSFER:
+            u8x8->gpio_and_delay_cb(u8x8, U8X8_MSG_DELAY_NANO, u8x8->display_info->pre_chip_disable_wait_ns, NULL);
+            u8x8_gpio_SetCS(u8x8, u8x8->display_info->chip_disable_level);
+            break;
+
+        default:
+            return 0;
+    }
+    return 1;
+}
+#endif /* U8G2_USE_HW_SPI */

--- a/sys/rt-thread/port/u8g2_port.h
+++ b/sys/rt-thread/port/u8g2_port.h
@@ -1,0 +1,44 @@
+#ifndef __U8G_PORT_H__
+#define __U8G_PORT_H__
+
+#include <rtthread.h>
+#include <rtdevice.h>
+
+#define U8X8_USE_PINS
+#include <u8x8.h>
+#include <u8g2.h>
+
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+#define U8X8_USE_PINS
+
+#define U8G2_USE_HW_I2C
+#define U8G2_USE_HW_SPI
+
+#if defined U8G2_USE_HW_SPI
+    #include <drv_spi.h>
+
+    #ifndef U8G2_SPI_BUS_NAME
+        #define U8G2_SPI_BUS_NAME            "spi1" 
+    #endif
+
+    #ifndef U8G2_SPI_DEVICE_NAME
+        #define U8G2_SPI_DEVICE_NAME         "spi10"
+    #endif
+
+    uint8_t u8x8_byte_rt_4wire_hw_spi(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr);
+
+#endif
+
+#if defined U8G2_USE_HW_I2C
+
+    #ifndef U8G2_I2C_DEVICE_NAME
+        #define U8G2_I2C_DEVICE_NAME         "i2c1"
+    #endif
+
+    uint8_t u8x8_byte_rt_hw_i2c(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr);
+
+#endif
+
+uint8_t u8x8_rt_gpio_and_delay(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr);
+
+#endif /* __U8G_PORT_H__ */


### PR DESCRIPTION
Hi olikraus, 

Previously I ported u8g2 to RT-Thread, which is a burgeoning RTOS that supports 150+ boards.

https://www.rt-thread.io/board.html
https://github.com/olikraus/u8g2/wiki/Porting-to-new-MCU-platform#rt-thread

U8g2 is very popular among RT-Thread developers and it has been downloaded 7000+ times.

https://packages.rt-thread.org/en/search.html?search=u8g2

It would be great if you are willing to incorporate the port for RT-Thread into the upstream repo, so that developers from the RT-Thread community can always receive the latest feature.