### PR TITLE
added support to drawStr_P to print from flash memory using PSTR()

### DIFF
--- a/cppsrc/U8g2lib.h
+++ b/cppsrc/U8g2lib.h
@@ -279,6 +279,7 @@ u8g2_uint_t u8g2_GetUTF8Width(u8g2_t *u8g2, const char *str);
     
     u8g2_uint_t drawGlyph(u8g2_uint_t x, u8g2_uint_t y, uint16_t encoding) { return u8g2_DrawGlyph(&u8g2, x, y, encoding); }    
     u8g2_uint_t drawStr(u8g2_uint_t x, u8g2_uint_t y, const char *s) { return u8g2_DrawStr(&u8g2, x, y, s); }
+    u8g2_uint_t drawStr_P(u8g2_uint_t x, u8g2_uint_t y, const char * ifsh) { return u8g2_DrawStr_P(&u8g2, x, y, ifsh); }
     u8g2_uint_t drawUTF8(u8g2_uint_t x, u8g2_uint_t y, const char *s) { return u8g2_DrawUTF8(&u8g2, x, y, s); }
     u8g2_uint_t drawExtUTF8(u8g2_uint_t x, u8g2_uint_t y, uint8_t to_left, const uint16_t *kerning_table, const char *s) 
       { return u8g2_DrawExtUTF8(&u8g2, x, y, to_left, kerning_table, s); }

--- a/csrc/u8g2.h
+++ b/csrc/u8g2.h
@@ -1449,6 +1449,7 @@ int8_t u8g2_GetStrX(u8g2_t *u8g2, const char *s);	/* for u8g compatibility */
 
 void u8g2_SetFontDirection(u8g2_t *u8g2, uint8_t dir);
 u8g2_uint_t u8g2_DrawStr(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, const char *str);
+u8g2_uint_t u8g2_DrawStr_P(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, const char*  ifsh);
 u8g2_uint_t u8g2_DrawUTF8(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, const char *str);
 u8g2_uint_t u8g2_DrawExtendedUTF8(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, uint8_t to_left, u8g2_kerning_t *kerning, const char *str);
 u8g2_uint_t u8g2_DrawExtUTF8(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, uint8_t to_left, const uint16_t *kerning_table, const char *str);

--- a/csrc/u8g2_font.c
+++ b/csrc/u8g2_font.c
@@ -845,6 +845,12 @@ u8g2_uint_t u8g2_DrawStr(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, const char 
   return u8g2_draw_string(u8g2, x, y, str);
 }
 
+u8g2_uint_t u8g2_DrawStr_P(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, const char*  ifsh)
+{
+  u8g2->u8x8.next_cb = u8x8_ascii_next_pgm;
+  PGM_P str = ifsh;
+  return u8g2_draw_string(u8g2, x, y, str);
+}
 /*
 source: https://en.wikipedia.org/wiki/UTF-8
 Bits	from 		to			bytes	Byte 1 		Byte 2 		Byte 3 		Byte 4 		Byte 5 		Byte 6

--- a/csrc/u8x8.h
+++ b/csrc/u8x8.h
@@ -977,6 +977,7 @@ uint16_t u8x8_upscale_byte(uint8_t x) U8X8_NOINLINE;
 
 void u8x8_utf8_init(u8x8_t *u8x8);
 uint16_t u8x8_ascii_next(u8x8_t *u8x8, uint8_t b);
+uint16_t u8x8_ascii_next_pgm(u8x8_t *u8x8, uint8_t b_);
 uint16_t u8x8_utf8_next(u8x8_t *u8x8, uint8_t b);
 // the following two functions are replaced by the init/next functions 
 //uint16_t u8x8_get_encoding_from_utf8_string(const char **str);

--- a/csrc/u8x8_8x8.c
+++ b/csrc/u8x8_8x8.c
@@ -294,6 +294,13 @@ uint16_t u8x8_ascii_next(U8X8_UNUSED u8x8_t *u8x8, uint8_t b)
   return b;
 }
 
+uint16_t u8x8_ascii_next_pgm(U8X8_UNUSED u8x8_t *u8x8, uint8_t b_)
+{
+  uint8_t b = pgm_read_byte(b_);
+  if (b == 0 || b == '\n') /* '\n' terminates the string to support the ring ////list procedures */
+    return 0x0ffff;        /* end of string detected*/
+  return b;
+}
 /*
   pass a byte from an utf8 encoded string to the utf8 decoder state machine
   returns 


### PR DESCRIPTION
printing from flash memory instead of RAM is not possible with `DrawStr` or other u8g2 function, only with inherented `print`class and using its `__Flashhelper` overload with the `setCursor()`. But It might me more elegent to use  the added `DrawStr_P()` function, following a similair naming scheme as stdio.h. 

Thus it would be used as such:
u8g2.drawStr_P(0, 9, PSTR("Hello World!"));

in contrast to :
u8g2.setCursor(0,9);
u8g2.print(F("hello World!"));