### PR TITLE
Extend UTF8 encoding for complete compatibility

### DIFF
--- a/csrc/u8g2.h
+++ b/csrc/u8g2.h
@@ -1502,9 +1502,9 @@ size_t u8g2_GetFontSize(const uint8_t *font_arg);
 void u8g2_SetFont(u8g2_t *u8g2, const uint8_t  *font);
 void u8g2_SetFontMode(u8g2_t *u8g2, uint8_t is_transparent);
 
-uint8_t u8g2_IsGlyph(u8g2_t *u8g2, uint16_t requested_encoding);
-int8_t u8g2_GetGlyphWidth(u8g2_t *u8g2, uint16_t requested_encoding);
-u8g2_uint_t u8g2_DrawGlyph(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, uint16_t encoding);
+uint8_t u8g2_IsGlyph(u8g2_t *u8g2, uint32_t requested_encoding);
+int8_t u8g2_GetGlyphWidth(u8g2_t *u8g2, uint32_t requested_encoding);
+u8g2_uint_t u8g2_DrawGlyph(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, uint32_t encoding);
 int8_t u8g2_GetStrX(u8g2_t *u8g2, const char *s);	/* for u8g compatibility */
 
 void u8g2_SetFontDirection(u8g2_t *u8g2, uint8_t dir);

--- a/csrc/u8g2_font.c
+++ b/csrc/u8g2_font.c
@@ -624,7 +624,7 @@ int8_t u8g2_font_decode_glyph(u8g2_t *u8g2, const uint8_t *glyph_data)
   Return:
     Address of the glyph data or NULL, if the encoding is not avialable in the font.
 */
-const uint8_t *u8g2_font_get_glyph_data(u8g2_t *u8g2, uint16_t encoding)
+const uint8_t *u8g2_font_get_glyph_data(u8g2_t *u8g2, uint32_t encoding)
 {
   const uint8_t *font = u8g2->font;
   font += U8G2_FONT_DATA_STRUCT_SIZE;
@@ -711,7 +711,7 @@ const uint8_t *u8g2_font_get_glyph_data(u8g2_t *u8g2, uint16_t encoding)
   return NULL;
 }
 
-static u8g2_uint_t u8g2_font_draw_glyph(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, uint16_t encoding)
+static u8g2_uint_t u8g2_font_draw_glyph(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, uint32_t encoding)
 {
   u8g2_uint_t dx = 0;
   u8g2->font_decode.target_x = x;
@@ -728,7 +728,7 @@ static u8g2_uint_t u8g2_font_draw_glyph(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t
 
 
 
-uint8_t u8g2_IsGlyph(u8g2_t *u8g2, uint16_t requested_encoding)
+uint8_t u8g2_IsGlyph(u8g2_t *u8g2, uint32_t requested_encoding)
 {
   /* updated to new code */
   if ( u8g2_font_get_glyph_data(u8g2, requested_encoding) != NULL )
@@ -737,7 +737,7 @@ uint8_t u8g2_IsGlyph(u8g2_t *u8g2, uint16_t requested_encoding)
 }
 
 /* side effect: updates u8g2->font_decode and u8g2->glyph_x_offset */
-int8_t u8g2_GetGlyphWidth(u8g2_t *u8g2, uint16_t requested_encoding)
+int8_t u8g2_GetGlyphWidth(u8g2_t *u8g2, uint32_t requested_encoding)
 {
   const uint8_t *glyph_data = u8g2_font_get_glyph_data(u8g2, requested_encoding);
   if ( glyph_data == NULL )
@@ -765,7 +765,7 @@ void u8g2_SetFontMode(u8g2_t *u8g2, uint8_t is_transparent)
   u8g2->font_decode.is_transparent = is_transparent;		// new font procedures
 }
 
-u8g2_uint_t u8g2_DrawGlyph(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, uint16_t encoding)
+u8g2_uint_t u8g2_DrawGlyph(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, uint32_t encoding)
 {
 #ifdef U8G2_WITH_FONT_ROTATION
   switch(u8g2->font_decode.dir)
@@ -792,7 +792,7 @@ u8g2_uint_t u8g2_DrawGlyph(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, uint16_t 
 static u8g2_uint_t u8g2_draw_string(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, const char *str) U8G2_NOINLINE;
 static u8g2_uint_t u8g2_draw_string(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, const char *str)
 {
-  uint16_t e;
+  uint32_t e;
   u8g2_uint_t delta, sum;
   u8x8_utf8_init(u8g2_GetU8x8(u8g2));
   sum = 0;

--- a/csrc/u8x8.h
+++ b/csrc/u8x8.h
@@ -203,7 +203,7 @@ typedef struct u8x8_display_info_struct u8x8_display_info_t;
 typedef struct u8x8_tile_struct u8x8_tile_t;
 
 typedef uint8_t (*u8x8_msg_cb)(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr);
-typedef uint16_t (*u8x8_char_cb)(u8x8_t *u8x8, uint8_t b);
+typedef uint32_t (*u8x8_char_cb)(u8x8_t *u8x8, uint8_t b);
 
 
 
@@ -339,7 +339,7 @@ struct u8x8_struct
   u8x8_msg_cb gpio_and_delay_cb;
   uint32_t bus_clock;	/* can be used by the byte function to store the clock speed of the bus */
   const uint8_t *font;
-  uint16_t encoding;		/* encoding result for utf8 decoder in next_cb */
+  uint32_t encoding;		/* encoding result for utf8 decoder in next_cb */
   uint8_t x_offset;	/* copied from info struct, can be modified in flip mode */
   uint8_t is_font_inverse_mode; 	/* 0: normal, 1: font glyphs are inverted */
   uint8_t i2c_address;	/* a valid i2c adr. Initially this is 255, but this is set to something usefull during DISPLAY_INIT */
@@ -981,8 +981,8 @@ uint16_t u8x8_upscale_byte(uint8_t x) U8X8_NOINLINE;
 
 
 void u8x8_utf8_init(u8x8_t *u8x8);
-uint16_t u8x8_ascii_next(u8x8_t *u8x8, uint8_t b);
-uint16_t u8x8_utf8_next(u8x8_t *u8x8, uint8_t b);
+uint32_t u8x8_ascii_next(u8x8_t *u8x8, uint8_t b);
+uint32_t u8x8_utf8_next(u8x8_t *u8x8, uint8_t b);
 // the following two functions are replaced by the init/next functions 
 //uint16_t u8x8_get_encoding_from_utf8_string(const char **str);
 //uint16_t u8x8_get_char_from_string(const char **str);


### PR DESCRIPTION
**u8x8_utf8_next** is able to decode the entire UTF8 range, but the encoding exceeds the uint16_t storage size.
Usually it won't be a problem, but the unicode size is simply ludicrous.
To not hurt the performance, maybe we can add a switch to use uint16_t when not needing the extra range.
ex. Something like this:
```
// Defined somewhere, ex u8g2.h
#define USE_EXTENDED_UTF8

// Then
#ifdef USE_EXTENDED_UTF8
    typedef uint32_t encoding_t;
#else
    typedef uint16_t encoding_t;
#endif
  ```

Then use "encoding_t" for all these modified functions, like:
```
u8g2_uint_t u8g2_DrawGlyph(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, encoding_t encoding)
  ```

