### PR TITLE
[rt-thread] beautify rt-thread port codes

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -1,3 +1,5 @@
+# RT-Thread building script for bridge
+
 import os
 from building import *
 

--- a/csrc/u8x8.h
+++ b/csrc/u8x8.h
@@ -190,7 +190,7 @@ uint8_t u8x8_pgm_read_esp(const uint8_t * addr);   /* u8x8_8x8.c */
 #define U8X8_USE_PINS
 #endif
 
-#ifdef RTT_U8G2
+#ifdef __RTTHREAD__
 #define U8X8_USE_PINS
 #endif
 

--- a/sys/rt-thread/SConscript
+++ b/sys/rt-thread/SConscript
@@ -197,8 +197,6 @@ else:
 path    = [cwd + '/port']
 path   += [cwd + '/../../csrc']
 
-LOCAL_CCFLAGS = ''
-
-group = DefineGroup('U8G2', src, depend = ['PKG_USING_U8G2_OFFICIAL'], CPPPATH = path, LOCAL_CCFLAGS = LOCAL_CCFLAGS, CPPDEFINES=['RTT_U8G2'])
+group = DefineGroup('u8g2', src, depend = ['PKG_USING_U8G2_OFFICIAL'], CPPPATH = path)
 
 Return('group')


### PR DESCRIPTION
Use RT-Thread Standard label Micro to replace RTT_U8G2;
Add some comments for sconscript;
Remove LOCAL_CCFLAGS .
@wuhanstudio please review.
@olikraus please review.