### PR TITLE
[fix] rm codebuild.o

### DIFF
--- a/tools/codebuild/Makefile
+++ b/tools/codebuild/Makefile
@@ -13,7 +13,7 @@ codebuild: $(SRC)
 	$(CC) -Wall -g $(LDFLAGS) $(SRC) -o codebuild
 
 clean:	
-	-rm ./codebuild codebuild.o
+	-rm ./codebuild
 
 build: codebuild
 	./codebuild


### PR DESCRIPTION
When I try to `make clean` under the `codebuild` directory, it returns the error:
```
codebuild.o does not exist
```

Because indeed `codebuild.o` is not generated when compiling use `-o`:

```
$(CC) -Wall -g $(LDFLAGS) $(SRC) -o codebuild
```