### PR TITLE
[fix][rt-thread] rm codebuild.o from Makefile

### DIFF
--- a/sys/rt-thread/tools/Makefile
+++ b/sys/rt-thread/tools/Makefile
@@ -13,7 +13,7 @@ codebuild: $(SRC)
 	$(CC) -Wall -g $(LDFLAGS) $(SRC) -o codebuild
 
 clean:	
-	-rm ./codebuild codebuild.o
+	-rm ./codebuild
 
 build: codebuild
 	./codebuild


### PR DESCRIPTION
The same fix as https://github.com/olikraus/u8g2/pull/1609 for rt-thread codebuild Makefile.