### PR TITLE
Use yield() only when #defiend ARDUINO

### DIFF
--- a/cppsrc/U8g2lib.cpp
+++ b/cppsrc/U8g2lib.cpp
@@ -44,7 +44,9 @@ static Print *u8g2_print_for_screenshot;
 
 void u8g2_print_callback(const char *s)
 { 
+#ifdef ARDUINO
   yield(); 
+#endif
   u8g2_print_for_screenshot->print(s); 
 }
 


### PR DESCRIPTION
Hi, 

Some platforms do not provide the yield() funtion.

I'm not sure if this yield() is required, and I uncommented this line for the RTT and arm-linux port. If we do not use yield(), different ports can share the same `U8g2lib.cpp`.

Or it's better to do it this way, if this is required for the Arduino platform:

```
#ifdef ARDUINO
  yield(); 
#endif
```