### PR TITLE
Use the same U8g2lib.cpp and U8x8lib.cpp for different ports

### DIFF
--- a/sys/arm-linux/port/U8g2lib.cpp
+++ b/sys/arm-linux/port/U8g2lib.cpp
@@ -44,7 +44,9 @@ static Print *u8g2_print_for_screenshot;
 
 void u8g2_print_callback(const char *s)
 { 
-  // yield(); 
+#ifdef ARDUINO
+  yield(); 
+#endif
   u8g2_print_for_screenshot->print(s); 
 }
 

--- a/sys/arm-linux/port/U8x8lib.cpp
+++ b/sys/arm-linux/port/U8x8lib.cpp
@@ -1650,6 +1650,7 @@ extern "C" uint8_t u8x8_byte_arduino_ks0108(u8x8_t *u8x8, uint8_t msg, uint8_t a
 
 
 
+
 #ifdef U8X8_USE_PINS
 
 /*

--- a/sys/rt-thread/port/U8g2lib.cpp
+++ b/sys/rt-thread/port/U8g2lib.cpp
@@ -44,7 +44,9 @@ static Print *u8g2_print_for_screenshot;
 
 void u8g2_print_callback(const char *s)
 { 
-//  yield();
+#ifdef ARDUINO
+  yield(); 
+#endif
   u8g2_print_for_screenshot->print(s); 
 }
 

--- a/sys/rt-thread/port/U8x8lib.cpp
+++ b/sys/rt-thread/port/U8x8lib.cpp
@@ -49,6 +49,7 @@
 #endif
 
 
+
 /*=============================================*/
 
 size_t U8X8::write(uint8_t v) 
@@ -1641,8 +1642,9 @@ extern "C" uint8_t u8x8_byte_arduino_ks0108(u8x8_t *u8x8, uint8_t msg, uint8_t a
 }
   
 #endif
+#endif /*ARDUINO*/
 
-#endif
+
 
 
 


### PR DESCRIPTION
Now different ports can use exactly the same `U8x8lib.cpp` and `U8g2lib.cpp`.

```
diff cppsrc/U8x8lib.cpp sys/rt-thread/port/U8x8lib.cpp
diff cppsrc/U8g2lib.cpp sys/rt-thread/port/U8g2lib.cpp

diff cppsrc/U8x8lib.cpp sys/arm-linux/port/U8x8lib.cpp
diff cppsrc/U8g2lib.cpp sys/arm-linux/port/U8g2lib.cpp
```