### PR TITLE
fix Wire.begin for esp32

### DIFF
--- a/cppsrc/U8x8lib.cpp
+++ b/cppsrc/U8x8lib.cpp
@@ -1319,7 +1319,7 @@ extern "C" uint8_t u8x8_byte_arduino_hw_i2c(U8X8_UNUSED u8x8_t *u8x8, U8X8_UNUSE
       if ( u8x8->pins[U8X8_PIN_I2C_CLOCK] != U8X8_PIN_NONE && u8x8->pins[U8X8_PIN_I2C_DATA] != U8X8_PIN_NONE )
       {
 	// second argument for the wire lib is the clock pin. In u8g2, the first argument of the  clock pin in the clock/data pair
-	Wire.begin(u8x8->pins[U8X8_PIN_I2C_DATA] , u8x8->pins[U8X8_PIN_I2C_CLOCK]);
+	Wire.begin((int)u8x8->pins[U8X8_PIN_I2C_DATA] , u8x8->pins[U8X8_PIN_I2C_CLOCK]);
       }
       else
       {


### PR DESCRIPTION
esp32 Wire.begin has been overloaded such that if the first parameter is a uint8_t, it keys as a slave device.  So, cast the pin to be int.  I do not have a esp8266 around to test, so would recommend checking that it doesn't affect them.