### PR TITLE
[fix][arm-linux][gpio] fopen w+ --> fopen w

### DIFF
--- a/sys/arm-linux/drivers/gpio.c
+++ b/sys/arm-linux/drivers/gpio.c
@@ -47,7 +47,7 @@ static int readIntValueFromFile(char* fileName)
 
 int exportGPIOPin(int pin) 
 {
-    FILE* fp = fopen("/sys/class/gpio/export", "w+");
+    FILE* fp = fopen("/sys/class/gpio/export", "w");
     if (fp != NULL) 
     {
         fprintf(fp, "%d", pin);
@@ -63,7 +63,7 @@ int exportGPIOPin(int pin)
 
 int unexportGPIOPin(int pin) 
 {
-    FILE* fp = fopen("/sys/class/gpio/unexport", "w+");
+    FILE* fp = fopen("/sys/class/gpio/unexport", "w");
     if (fp != NULL) 
     {
         fprintf(fp, "%d", pin);
@@ -95,7 +95,7 @@ int setGPIOValue(int pin, int value)
     else
     {
         GPIO_FILENAME_DEFINE(pin, "value")
-        fp_gpio[pin] = fopen(fileName, "w+");
+        fp_gpio[pin] = fopen(fileName, "w");
         if (fp_gpio[pin] != NULL) 
         {
             fprintf(fp_gpio[pin], "%d", value);


### PR DESCRIPTION
After running several tests, indeed as suggested by @sgjava https://github.com/olikraus/u8g2/issues/1638#issuecomment-955608269, fopen with `w` works for both `ubuntu 5.4.0-1045-raspi` and `armbian 5.10.34-sunxi`.

This PR change all the `w+` to `w` in gpio.c.