### PR TITLE
Add I2C and SPI buses

### DIFF
--- a/csrc/u8x8.h
+++ b/csrc/u8x8.h
@@ -346,7 +346,6 @@ struct u8x8_struct
   uint16_t encoding;		/* encoding result for utf8 decoder in next_cb */
   uint8_t x_offset;	/* copied from info struct, can be modified in flip mode */
   uint8_t is_font_inverse_mode; 	/* 0: normal, 1: font glyphs are inverted */
-  uint8_t device_id; /* unique device id */
   uint8_t spi_bus_num; /* spi bus to use */
   uint8_t i2c_bus_num; /* i2c bus to use */
   uint8_t i2c_address;	/* a valid i2c adr. Initially this is 255, but this is set to something usefull during DISPLAY_INIT */
@@ -376,8 +375,6 @@ struct u8x8_struct
 
 #define u8x8_GetCols(u8x8) ((u8x8)->display_info->tile_width)
 #define u8x8_GetRows(u8x8) ((u8x8)->display_info->tile_height)
-#define u8x8_GetDeviceID(u8x8) ((u8x8)->device_id)
-#define u8x8_SetDeviceID(u8x8, bus_num) ((u8x8)->device_id = (id))
 #define u8x8_GetSPIBus(u8x8) ((u8x8)->spi_bus_num)
 #define u8x8_SetSPIBus(u8x8, bus_num) ((u8x8)->spi_bus_num = (bus_num))
 #define u8x8_GetI2CBus(u8x8) ((u8x8)->i2c_bus_num)

--- a/csrc/u8x8.h
+++ b/csrc/u8x8.h
@@ -346,6 +346,8 @@ struct u8x8_struct
   uint16_t encoding;		/* encoding result for utf8 decoder in next_cb */
   uint8_t x_offset;	/* copied from info struct, can be modified in flip mode */
   uint8_t is_font_inverse_mode; 	/* 0: normal, 1: font glyphs are inverted */
+  uint8_t spi_bus_num; /* spi bus to use*/
+  uint8_t i2c_bus_num; /* i2c bus to use*/
   uint8_t i2c_address;	/* a valid i2c adr. Initially this is 255, but this is set to something usefull during DISPLAY_INIT */
 					/* i2c_address is the address for writing data to the display */
 					/* usually, the lowest bit must be zero for a valid address */
@@ -373,6 +375,10 @@ struct u8x8_struct
 
 #define u8x8_GetCols(u8x8) ((u8x8)->display_info->tile_width)
 #define u8x8_GetRows(u8x8) ((u8x8)->display_info->tile_height)
+#define u8x8_GetSPIBus(u8x8) ((u8x8)->spi_bus_num)
+#define u8x8_SetSPIBus(u8x8, bus_num) ((u8x8)->spi_bus_num = (bus_num))
+#define u8x8_GetI2CBus(u8x8) ((u8x8)->i2c_bus_num)
+#define u8x8_SetI2CBus(u8x8, bus_num) ((u8x8)->i2c_bus_num = (bus_num))
 #define u8x8_GetI2CAddress(u8x8) ((u8x8)->i2c_address)
 #define u8x8_SetI2CAddress(u8x8, address) ((u8x8)->i2c_address = (address))
 

--- a/csrc/u8x8.h
+++ b/csrc/u8x8.h
@@ -346,8 +346,9 @@ struct u8x8_struct
   uint16_t encoding;		/* encoding result for utf8 decoder in next_cb */
   uint8_t x_offset;	/* copied from info struct, can be modified in flip mode */
   uint8_t is_font_inverse_mode; 	/* 0: normal, 1: font glyphs are inverted */
-  uint8_t spi_bus_num; /* spi bus to use*/
-  uint8_t i2c_bus_num; /* i2c bus to use*/
+  uint8_t device_id; /* unique device id */
+  uint8_t spi_bus_num; /* spi bus to use */
+  uint8_t i2c_bus_num; /* i2c bus to use */
   uint8_t i2c_address;	/* a valid i2c adr. Initially this is 255, but this is set to something usefull during DISPLAY_INIT */
 					/* i2c_address is the address for writing data to the display */
 					/* usually, the lowest bit must be zero for a valid address */
@@ -375,6 +376,8 @@ struct u8x8_struct
 
 #define u8x8_GetCols(u8x8) ((u8x8)->display_info->tile_width)
 #define u8x8_GetRows(u8x8) ((u8x8)->display_info->tile_height)
+#define u8x8_GetDeviceID(u8x8) ((u8x8)->device_id)
+#define u8x8_SetDeviceID(u8x8, bus_num) ((u8x8)->device_id = (id))
 #define u8x8_GetSPIBus(u8x8) ((u8x8)->spi_bus_num)
 #define u8x8_SetSPIBus(u8x8, bus_num) ((u8x8)->spi_bus_num = (bus_num))
 #define u8x8_GetI2CBus(u8x8) ((u8x8)->i2c_bus_num)


### PR DESCRIPTION
@olikraus This is what we were discussing in the other PR I closed. By moving I2C and SPI bus numbers into u8x8_struct these can be removed from ports and calling programs can set them. I decided against device ID for now. This should allow you to close https://github.com/olikraus/u8g2/pull/1255 unless you want to cherry pick the display specific stuff. This is more generic.

@wuhanstudio this will allow me to remove hard coded buses from arm-linux. I need to think about how to handle I2C state (buffer) a bit and may add device ID back in. I figure one step at a time.