### PR TITLE
Make GPIO, SPI and I2C bus stateful

### DIFF
--- a/csrc/u8g2.h
+++ b/csrc/u8g2.h
@@ -415,8 +415,14 @@ void u8g2_ClearDisplay(u8g2_t *u8g2);
 #define u8g2_GetDisplayWidth(u8g2) ((u8g2)->width)
 #define u8g2_GetDrawColor(u8g2) ((u8g2)->draw_color)
 
-#define u8g2_SetI2CAddress(u8g2, address) ((u8g2_GetU8x8(u8g2))->i2c_address = (address))
+#define u8g2_GetGPIOChip(u8g2) u8x8_GetGPIOChip(u8g2_GetU8x8(u8g2))
+#define u8g2_SetGPIOChip(u8g2, chip_num) ((u8g2_GetU8x8(u8g2))->gpio_chip_num = (chip_num))
+#define u8g2_GetSPIBus(u8g2) u8x8_GetSPIBus(u8g2_GetU8x8(u8g2))
+#define u8g2_SetSPIBus(u8g2, bus_num) ((u8g2_GetU8x8(u8g2))->spi_bus_num = (bus_num))
+#define u8g2_GetI2CBus(u8g2) u8x8_GetI2CBus(u8g2_GetU8x8(u8g2))
+#define u8g2_SetI2CBus(u8g2, bus_num) ((u8g2_GetU8x8(u8g2))->i2c_bus_num = (bus_num))
 #define u8g2_GetI2CAddress(u8g2)   u8x8_GetI2CAddress(u8g2_GetU8x8(u8g2))
+#define u8g2_SetI2CAddress(u8g2, address) ((u8g2_GetU8x8(u8g2))->i2c_address = (address))
 
 #ifdef U8X8_USE_PINS 
 #define u8g2_SetMenuSelectPin(u8g2, val) u8x8_SetMenuSelectPin(u8g2_GetU8x8(u8g2), (val)) 

--- a/csrc/u8x8.h
+++ b/csrc/u8x8.h
@@ -346,6 +346,7 @@ struct u8x8_struct
   uint16_t encoding;		/* encoding result for utf8 decoder in next_cb */
   uint8_t x_offset;	/* copied from info struct, can be modified in flip mode */
   uint8_t is_font_inverse_mode; 	/* 0: normal, 1: font glyphs are inverted */
+  uint8_t gpio_chip_num; /* gpio chip  */
   uint8_t spi_bus_num; /* spi bus to use */
   uint8_t i2c_bus_num; /* i2c bus to use */
   uint8_t i2c_address;	/* a valid i2c adr. Initially this is 255, but this is set to something usefull during DISPLAY_INIT */
@@ -375,6 +376,8 @@ struct u8x8_struct
 
 #define u8x8_GetCols(u8x8) ((u8x8)->display_info->tile_width)
 #define u8x8_GetRows(u8x8) ((u8x8)->display_info->tile_height)
+#define u8x8_GetGPIOChip(u8x8) ((u8x8)->gpio_chip_num)
+#define u8x8_SetGPIOChip(u8x8, chip_num) ((u8x8)->gpio_chip_num = (chip_num))
 #define u8x8_GetSPIBus(u8x8) ((u8x8)->spi_bus_num)
 #define u8x8_SetSPIBus(u8x8, bus_num) ((u8x8)->spi_bus_num = (bus_num))
 #define u8x8_GetI2CBus(u8x8) ((u8x8)->i2c_bus_num)

--- a/csrc/u8x8.h
+++ b/csrc/u8x8.h
@@ -346,7 +346,6 @@ struct u8x8_struct
   uint16_t encoding;		/* encoding result for utf8 decoder in next_cb */
   uint8_t x_offset;	/* copied from info struct, can be modified in flip mode */
   uint8_t is_font_inverse_mode; 	/* 0: normal, 1: font glyphs are inverted */
-  uint8_t device_id; /* unique device id */
   uint8_t spi_bus_num; /* spi bus to use */
   uint8_t i2c_bus_num; /* i2c bus to use */
   uint8_t i2c_address;	/* a valid i2c adr. Initially this is 255, but this is set to something usefull during DISPLAY_INIT */
@@ -376,8 +375,6 @@ struct u8x8_struct
 
 #define u8x8_GetCols(u8x8) ((u8x8)->display_info->tile_width)
 #define u8x8_GetRows(u8x8) ((u8x8)->display_info->tile_height)
-#define u8x8_GetDeviceID(u8x8) ((u8x8)->device_id)
-#define u8x8_SetDeviceID(u8x8, bus_num) ((u8x8)->device_id = (id))
 #define u8x8_GetSPIBus(u8x8) ((u8x8)->spi_bus_num)
 #define u8x8_SetSPIBus(u8x8, bus_num) ((u8x8)->spi_bus_num = (bus_num))
 #define u8x8_GetI2CBus(u8x8) ((u8x8)->i2c_bus_num)

--- a/csrc/u8x8.h
+++ b/csrc/u8x8.h
@@ -346,6 +346,8 @@ struct u8x8_struct
   uint16_t encoding;		/* encoding result for utf8 decoder in next_cb */
   uint8_t x_offset;	/* copied from info struct, can be modified in flip mode */
   uint8_t is_font_inverse_mode; 	/* 0: normal, 1: font glyphs are inverted */
+  uint8_t spi_bus_num; /* spi bus to use*/
+  uint8_t i2c_bus_num; /* i2c bus to use*/
   uint8_t i2c_address;	/* a valid i2c adr. Initially this is 255, but this is set to something usefull during DISPLAY_INIT */
 					/* i2c_address is the address for writing data to the display */
 					/* usually, the lowest bit must be zero for a valid address */
@@ -373,6 +375,10 @@ struct u8x8_struct
 
 #define u8x8_GetCols(u8x8) ((u8x8)->display_info->tile_width)
 #define u8x8_GetRows(u8x8) ((u8x8)->display_info->tile_height)
+#define u8x8_GetSPIBus(u8x8) ((u8x8)->spi_bus_num)
+#define u8x8_SetSPIBus(u8x8, bus_num) ((u8x8)->spi_bus_num = (bus_num))
+#define u8x8_GetI2CBus(u8x8) ((u8x8)->i2c_bus_num)
+#define u8x8_SetI2CBus(u8x8, bus_num) ((u8x8)->i2c_bus_num = (bus_num))
 #define u8x8_GetI2CAddress(u8x8) ((u8x8)->i2c_address)
 #define u8x8_SetI2CAddress(u8x8, address) ((u8x8)->i2c_address = (address))
 

--- a/csrc/u8x8.h
+++ b/csrc/u8x8.h
@@ -346,8 +346,9 @@ struct u8x8_struct
   uint16_t encoding;		/* encoding result for utf8 decoder in next_cb */
   uint8_t x_offset;	/* copied from info struct, can be modified in flip mode */
   uint8_t is_font_inverse_mode; 	/* 0: normal, 1: font glyphs are inverted */
-  uint8_t spi_bus_num; /* spi bus to use*/
-  uint8_t i2c_bus_num; /* i2c bus to use*/
+  uint8_t device_id; /* unique device id */
+  uint8_t spi_bus_num; /* spi bus to use */
+  uint8_t i2c_bus_num; /* i2c bus to use */
   uint8_t i2c_address;	/* a valid i2c adr. Initially this is 255, but this is set to something usefull during DISPLAY_INIT */
 					/* i2c_address is the address for writing data to the display */
 					/* usually, the lowest bit must be zero for a valid address */
@@ -375,6 +376,8 @@ struct u8x8_struct
 
 #define u8x8_GetCols(u8x8) ((u8x8)->display_info->tile_width)
 #define u8x8_GetRows(u8x8) ((u8x8)->display_info->tile_height)
+#define u8x8_GetDeviceID(u8x8) ((u8x8)->device_id)
+#define u8x8_SetDeviceID(u8x8, bus_num) ((u8x8)->device_id = (id))
 #define u8x8_GetSPIBus(u8x8) ((u8x8)->spi_bus_num)
 #define u8x8_SetSPIBus(u8x8, bus_num) ((u8x8)->spi_bus_num = (bus_num))
 #define u8x8_GetI2CBus(u8x8) ((u8x8)->i2c_bus_num)

--- a/sys/arm-linux/examples/c-examples/u8g2_4wire_hw_spi/u8g2_4wire_hw_spi.c
+++ b/sys/arm-linux/examples/c-examples/u8g2_4wire_hw_spi/u8g2_4wire_hw_spi.c
@@ -1,6 +1,9 @@
 #include "u8g2port.h"
 
-// By default, SPI bus /dev/spidev0.0 is used, as defined in port/U8g2lib.h
+// GPIO chip number for character device
+#define GPIO_CHIP_NUM 0
+// SPI bus uses upper 4 bits and lower 4 bits, so 0x10 will be /dev/spidev1.0
+#define SPI_BUS 0x10
 #define OLED_SPI_PIN_RES            199
 #define OLED_SPI_PIN_DC             198
 
@@ -13,9 +16,10 @@ int main(void)
 
     // Initialization
     u8g2_Setup_ssd1306_128x64_noname_f(&u8g2, U8G2_R0, u8x8_byte_arm_linux_hw_spi, u8x8_arm_linux_gpio_and_delay);
+    u8g2_SetGPIOChip(&u8g2, GPIO_CHIP_NUM);
+    u8g2_SetSPIBus(&u8g2, SPI_BUS);
     u8x8_SetPin(u8g2_GetU8x8(&u8g2), U8X8_PIN_DC, OLED_SPI_PIN_DC);
     u8x8_SetPin(u8g2_GetU8x8(&u8g2), U8X8_PIN_RESET, OLED_SPI_PIN_RES);
-    // u8x8_SetPin(u8g2_GetU8x8(&u8g2), U8X8_PIN_CS, OLED_SPI_PIN_CS);
 
     u8g2_InitDisplay(&u8g2);
     u8g2_SetPowerSave(&u8g2, 0);

--- a/sys/arm-linux/examples/c-examples/u8g2_4wire_sw_spi/u8g2_4wire_sw_spi.c
+++ b/sys/arm-linux/examples/c-examples/u8g2_4wire_sw_spi/u8g2_4wire_sw_spi.c
@@ -1,5 +1,7 @@
 #include "u8g2port.h"
 
+// GPIO chip number for character device
+#define GPIO_CHIP_NUM 0
 
 #define OLED_SPI_PIN_MOSI           13
 #define OLED_SPI_PIN_SCK            26
@@ -15,6 +17,7 @@ int main(void)
 
     // Initialization
     u8g2_Setup_ssd1306_128x64_noname_f(&u8g2, U8G2_R0, u8x8_byte_4wire_sw_spi, u8x8_arm_linux_gpio_and_delay);
+    u8g2_SetGPIOChip(&u8g2, GPIO_CHIP_NUM);
     u8x8_SetPin(u8g2_GetU8x8(&u8g2), U8X8_PIN_RESET, OLED_SPI_PIN_RES);
     u8x8_SetPin(u8g2_GetU8x8(&u8g2), U8X8_PIN_DC, OLED_SPI_PIN_DC);
     u8x8_SetPin(u8g2_GetU8x8(&u8g2), U8X8_PIN_SPI_DATA, OLED_SPI_PIN_MOSI);

--- a/sys/arm-linux/examples/c-examples/u8g2_hw_i2c/u8g2_hw_i2c.c
+++ b/sys/arm-linux/examples/c-examples/u8g2_hw_i2c/u8g2_hw_i2c.c
@@ -1,11 +1,17 @@
 #include <u8g2port.h>
 
+// Set I2C bus and address
+#define I2C_BUS 0
+#define I2C_ADDRESS 0x3c * 2
+
 int main(void)
 {
     u8g2_t u8g2;
 
     // Initialization    
     u8g2_Setup_ssd1306_i2c_128x64_noname_f( &u8g2, U8G2_R0, u8x8_byte_arm_linux_hw_i2c, u8x8_arm_linux_gpio_and_delay);
+    u8g2_SetI2CBus(&u8g2, I2C_BUS);
+    u8g2_SetI2CAddress(&u8g2, I2C_ADDRESS);
     u8g2_InitDisplay(&u8g2);
     u8g2_SetPowerSave(&u8g2, 0);
 

--- a/sys/arm-linux/examples/c-examples/u8g2_sw_i2c/u8g2_sw_i2c.c
+++ b/sys/arm-linux/examples/c-examples/u8g2_sw_i2c/u8g2_sw_i2c.c
@@ -1,5 +1,7 @@
 #include "u8g2port.h"
 
+// GPIO chip number for character device
+#define GPIO_CHIP_NUM 0
 #define OLED_I2C_PIN_SCL                    20
 #define OLED_I2C_PIN_SDA                    21
 
@@ -9,6 +11,7 @@ int main(void)
 
     // Initialization
     u8g2_Setup_ssd1306_i2c_128x64_noname_f( &u8g2, U8G2_R0, u8x8_byte_sw_i2c, u8x8_arm_linux_gpio_and_delay);
+    u8g2_SetGPIOChip(&u8g2, GPIO_CHIP_NUM);
     u8x8_SetPin(u8g2_GetU8x8(&u8g2), U8X8_PIN_I2C_CLOCK, OLED_I2C_PIN_SCL);
     u8x8_SetPin(u8g2_GetU8x8(&u8g2), U8X8_PIN_I2C_DATA, OLED_I2C_PIN_SDA);
     u8x8_SetPin(u8g2_GetU8x8(&u8g2), U8X8_PIN_RESET, U8X8_PIN_NONE);

--- a/sys/arm-linux/examples/cpp-examples/u8g2_4wire_hw_spi/u8g2_4wire_hw_spi.cpp
+++ b/sys/arm-linux/examples/cpp-examples/u8g2_4wire_hw_spi/u8g2_4wire_hw_spi.cpp
@@ -1,6 +1,9 @@
 #include <U8g2lib.h>
 
-// By default, SPI bus /dev/spidev0.0 is used, as defined in port/U8g2lib.h
+// GPIO chip number for character device
+#define GPIO_CHIP_NUM 0
+// SPI bus uses upper 4 bits and lower 4 bits, so 0x10 will be /dev/spidev1.0
+#define SPI_BUS 0x10
 #define OLED_SPI_PIN_RES            199
 #define OLED_SPI_PIN_DC             198
 
@@ -16,8 +19,9 @@ static U8G2_SSD1306_128X64_NONAME_F_4W_HW_SPI u8g2(U8G2_R0,
 
 int main()
 {
+	u8g2.setGpioChip(GPIO_CHIP_NUM);
+	u8g2.setSpiBus(SPI_BUS);
     u8g2.begin();
-    u8g2.clearBuffer();                         // clear the internal memory
     u8g2.setFont(u8g2_font_6x13_tr);            // choose a suitable font
     u8g2.drawStr(1, 18, "U8g2 on HW SPI");   // write something to the internal memory
     u8g2.sendBuffer();                          // transfer internal memory to the display

--- a/sys/arm-linux/examples/cpp-examples/u8g2_4wire_sw_spi/u8g2_4wire_sw_spi.cpp
+++ b/sys/arm-linux/examples/cpp-examples/u8g2_4wire_sw_spi/u8g2_4wire_sw_spi.cpp
@@ -1,5 +1,7 @@
 #include <U8g2lib.h>
 
+// GPIO chip number for character device
+#define GPIO_CHIP_NUM 0
 #define OLED_SPI_PIN_MOSI           13
 #define OLED_SPI_PIN_SCK            26
 
@@ -18,6 +20,7 @@ static U8G2_SSD1306_128X64_NONAME_F_4W_SW_SPI u8g2(U8G2_R0,\
 
 int main()
 {
+	u8g2.setGpioChip(GPIO_CHIP_NUM);
     u8g2.begin();
     u8g2.clearBuffer();                         // clear the internal memory
     u8g2.setFont(u8g2_font_6x13_tr);            // choose a suitable font

--- a/sys/arm-linux/examples/cpp-examples/u8g2_4wire_sw_spi/u8g2_4wire_sw_spi.cpp
+++ b/sys/arm-linux/examples/cpp-examples/u8g2_4wire_sw_spi/u8g2_4wire_sw_spi.cpp
@@ -22,7 +22,6 @@ int main()
 {
 	u8g2.setGpioChip(GPIO_CHIP_NUM);
     u8g2.begin();
-    u8g2.clearBuffer();                         // clear the internal memory
     u8g2.setFont(u8g2_font_6x13_tr);            // choose a suitable font
     u8g2.drawStr(1, 18, "U8g2 on SW SPI");   // write something to the internal memory
     u8g2.sendBuffer();                          // transfer internal memory to the display

--- a/sys/arm-linux/examples/cpp-examples/u8g2_hw_i2c_cpp/u8g2_hw_i2c.cpp
+++ b/sys/arm-linux/examples/cpp-examples/u8g2_hw_i2c_cpp/u8g2_hw_i2c.cpp
@@ -1,12 +1,16 @@
 #include <U8g2lib.h>
 
+// Set I2C bus and address
+#define I2C_BUS 0
+#define I2C_ADDRESS 0x3c * 2
 // Check https://github.com/olikraus/u8g2/wiki/u8g2setupcpp for all supported devices
 static U8G2_SSD1306_128X64_NONAME_F_HW_I2C  u8g2(U8G2_R0, /* reset=*/ U8X8_PIN_NONE);
 
 int main(void)
 {
+	u8g2.setI2cBus(I2C_BUS);
+	u8g2.setI2CAddress(I2C_ADDRESS);
     u8g2.begin();
-    u8g2.clearBuffer();                         // clear the internal memory
     u8g2.setFont(u8g2_font_6x13_tr);            // choose a suitable font
     u8g2.drawStr(1, 18, "U8g2 on HW I2C");   // write something to the internal memory
     u8g2.sendBuffer();                          // transfer internal memory to the display

--- a/sys/arm-linux/examples/cpp-examples/u8g2_sw_i2c_cpp/u8g2_sw_i2c.cpp
+++ b/sys/arm-linux/examples/cpp-examples/u8g2_sw_i2c_cpp/u8g2_sw_i2c.cpp
@@ -16,7 +16,6 @@ int main(void)
 {
 	u8g2.setGpioChip(GPIO_CHIP_NUM);
     u8g2.begin();
-    u8g2.clearBuffer();                         // clear the internal memory
     u8g2.setFont(u8g2_font_6x13_tr);            // choose a suitable font
     u8g2.drawStr(1, 18, "U8g2 on SW I2C");   // write something to the internal memory
     u8g2.sendBuffer();                          // transfer internal memory to the display

--- a/sys/arm-linux/examples/cpp-examples/u8g2_sw_i2c_cpp/u8g2_sw_i2c.cpp
+++ b/sys/arm-linux/examples/cpp-examples/u8g2_sw_i2c_cpp/u8g2_sw_i2c.cpp
@@ -1,5 +1,7 @@
 #include <U8g2lib.h>
 
+// GPIO chip number for character device
+#define GPIO_CHIP_NUM 0
 #define OLED_I2C_PIN_SCL                    20
 #define OLED_I2C_PIN_SDA                    21
 
@@ -12,6 +14,7 @@ static U8G2_SSD1306_128X64_NONAME_F_SW_I2C u8g2(U8G2_R0,
 
 int main(void)
 {
+	u8g2.setGpioChip(GPIO_CHIP_NUM);
     u8g2.begin();
     u8g2.clearBuffer();                         // clear the internal memory
     u8g2.setFont(u8g2_font_6x13_tr);            // choose a suitable font

--- a/sys/arm-linux/port/U8g2lib.h
+++ b/sys/arm-linux/port/U8g2lib.h
@@ -69,6 +69,16 @@ class U8G2 : public Print
     uint32_t getBusClock(void) { return u8g2_GetU8x8(&u8g2)->bus_clock; }
     void setBusClock(uint32_t clock_speed) { u8g2_GetU8x8(&u8g2)->bus_clock = clock_speed; }
 
+    uint8_t getGpioChip(void) { return u8x8_GetGPIOChip(u8g2_GetU8x8(&u8g2)); }
+    void setGpioChip(uint8_t num) { u8x8_SetGPIOChip(u8g2_GetU8x8(&u8g2), num); }
+
+    uint8_t getSpiBus(void) { return u8x8_GetSPIBus(u8g2_GetU8x8(&u8g2)); }
+    void setSpiBus(uint8_t num) { u8x8_SetSPIBus(u8g2_GetU8x8(&u8g2), num); }
+
+    uint8_t getI2cBus(void) { return u8x8_GetI2CBus(u8g2_GetU8x8(&u8g2)); }
+    void setI2cBus(uint8_t num) { u8x8_SetI2CBus(u8g2_GetU8x8(&u8g2), num); }
+
+    uint8_t getI2CAddress(void) { return u8g2_GetI2CAddress(&u8g2); }
     void setI2CAddress(uint8_t adr) { u8g2_SetI2CAddress(&u8g2, adr); }
     
     


### PR DESCRIPTION
@olikraus This is what we discussed as far as being able to have bus state in u8x8_t for GPIO device SPI and I2C buses. It adds only 3 bytes to the struct, but allows ports to be more configurable and have multiple displays more easily supported.

@wuhanstudio I reworked arm-linux and it's a lot more flexible now without hard coding the buses. Please take a peek at https://github.com/sgjava/u8g2 fork.