### PR TITLE
Remove exit on error

### DIFF
--- a/sys/arm-linux/README.md
+++ b/sys/arm-linux/README.md
@@ -5,7 +5,8 @@
 * Overall performance should be better.
 * Run as non-root user.
 * Thread safe and multiple display capable.
-* For Java check out [Java U8g2](https://github.com/sgjava/java-u8g2) which uses arm-linux port.
+* For Java check out [Java UIO U8g2](https://github.com/sgjava/javauio/tree/main/u8g2)
+which uses arm-linux port.
 
 ## Non-root access
 If you want to access devices without root do the following (you can try udev

--- a/sys/arm-linux/port/u8g2port.c
+++ b/sys/arm-linux/port/u8g2port.c
@@ -158,7 +158,6 @@ void init_pin(u8x8_t *u8x8, uint8_t pin) {
 			fprintf(stderr, "gpio_open(): pin %d, %s\n", u8x8->pins[pin],
 					gpio_errmsg(user_data -> pins[pin]));
 			gpio_free(user_data->pins[pin]);
-			exit(error);
 		}
 	}
 }
@@ -173,7 +172,6 @@ void init_pin(u8x8_t *u8x8, uint8_t pin) {
 			fprintf(stderr, "gpio_open_sysfs(): pin %d, %s\n", u8x8->pins[pin],
 					gpio_errmsg(user_data->pins[pin]));
 			gpio_free(user_data->pins[pin]);
-			exit(error);
 		}
 	}
 }
@@ -205,7 +203,6 @@ void init_i2c(u8x8_t *u8x8) {
 					i2c_errmsg(i2c_handles[user_data->bus]));
 			i2c_free(i2c_handles[user_data->bus]);
 			i2c_handles[user_data->bus] = NULL;
-			exit(error);
 		}
 	}
 }
@@ -247,7 +244,6 @@ void init_spi(u8x8_t *u8x8) {
 					spi_errmsg(spi_handles[user_data->bus]));
 			spi_free(spi_handles[user_data->bus]);
 			spi_handles[user_data->bus] = NULL;
-			exit(error);
 		}
 	}
 }


### PR DESCRIPTION
@olikraus I removed the exit on error and updated the readme. I was wondering if there's a cleaner way to detect errors from callbacks and let the calling program see them. i.e. u8g2_InitDisplay and other methods return an int error code (0 for no error). I'm not sure where to start. I guess I could handle this by adding some probe functions in the arm-linux port that uses same init args and tries at least to create resource (GPIO pin and I2C/SPI busses).

In any event I don't like the hard exit because you still may want your program to execute without the display. I left in the output to stderr, so at least you'll know why.