### PR TITLE
Add #ifdefs to make C++ interface usable without Arduino.

### DIFF
--- a/cppsrc/U8g2lib.cpp
+++ b/cppsrc/U8g2lib.cpp
@@ -39,14 +39,12 @@
 
 #include "U8g2lib.h"
 
+#ifdef ARDUINO
 static Print *u8g2_print_for_screenshot;
-
 
 void u8g2_print_callback(const char *s)
 { 
-#ifdef ARDUINO
   yield(); 
-#endif
   u8g2_print_for_screenshot->print(s); 
 }
 
@@ -73,6 +71,6 @@ void U8G2::writeBufferXBM2(Print &p)
   u8g2_print_for_screenshot = &p;
   u8g2_WriteBufferXBM2(getU8g2(), u8g2_print_callback);
 }
-
+#endif
 
 

--- a/cppsrc/U8g2lib.h
+++ b/cppsrc/U8g2lib.h
@@ -45,13 +45,19 @@
 #ifndef U8G2LIB_HH
 #define U8G2LIB_HH
 
+#ifdef ARDUINO
 #include <Arduino.h>
 #include <Print.h>
+#endif
+
 #include "U8x8lib.h"
 
 #include "u8g2.h"
 
-class U8G2 : public Print
+class U8G2
+#ifdef ARDUINO
+: public Print
+#endif
 {
   protected:
     u8g2_t u8g2;
@@ -294,6 +300,7 @@ u8g2_uint_t u8g2_GetUTF8Width(u8g2_t *u8g2, const char *str);
     // not required any more, enable UTF8 for print 
     //void printUTF8(const char *s) { tx += u8g2_DrawUTF8(&u8g2, tx, ty, s); }
 	
+#ifdef ARDUINO
     /* screenshot functions for full buffer mode */
     /* vertical top lsb memory architecture */
     void writeBufferPBM(Print &p);
@@ -302,6 +309,7 @@ u8g2_uint_t u8g2_GetUTF8Width(u8g2_t *u8g2, const char *str);
     /* SH1122, LD7032, ST7920, ST7986, LC7981, T6963, SED1330, RA8835, MAX7219, LS0 */ 
     void writeBufferPBM2(Print &p);
     void writeBufferXBM2(Print &p);
+#endif
 
     /* virtual function for print base class */    
     size_t write(uint8_t v) {
@@ -390,7 +398,10 @@ uint8_t u8g2_UserInterfaceInputValue(u8g2_t *u8g2, const char *title, const char
 void u8g2_print_callback(const char *s);  /* U8g2lib.cpp */
 
 
-class U8G2LOG : public Print
+class U8G2LOG
+#ifdef ARDUINO
+: public Print
+#endif
 {
   
   public:

--- a/cppsrc/U8x8lib.h
+++ b/cppsrc/U8x8lib.h
@@ -39,8 +39,10 @@
 #ifndef U8X8LIB_HH
 #define U8X8LIB_HH
 
+#ifdef ARDUINO
 #include <Arduino.h>
 #include <Print.h>
+#endif
 
 #include "u8x8.h"
 
@@ -166,7 +168,10 @@ void u8x8_SetPin_SED1520(u8x8_t *u8x8, uint8_t d0, uint8_t d1, uint8_t d2, uint8
 //void u8x8_Setup_8Bit_6800(u8x8_t *u8x8, u8x8_msg_cb display_cb, uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3, uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7, uint8_t enable, uint8_t cs, uint8_t dc, uint8_t reset);
 //void u8x8_Setup_8Bit_8080(u8x8_t *u8x8, u8x8_msg_cb display_cb, uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3, uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7, uint8_t wr, uint8_t cs, uint8_t dc, uint8_t reset);
 
-class U8X8 : public Print
+class U8X8
+#ifdef ARDUINO
+: public Print
+#endif
 {
   protected:
     u8x8_t u8x8;
@@ -336,7 +341,10 @@ class U8X8 : public Print
     
 };
 
-class U8X8LOG : public Print
+class U8X8LOG
+#ifdef ARDUINO
+: public Print
+#endif
 {
   
   public:


### PR DESCRIPTION
I would like to use the C++ interface but without Arduino dependency.

It seems `#ifdef ARDUINO` is already used in a few places in the code, so this pull request expands it so that the C++ interface can be built without any need for Arduino functions.