### PR TITLE
add a global define that can disable Wire.setClock()

### DIFF
--- a/cppsrc/U8x8lib.cpp
+++ b/cppsrc/U8x8lib.cpp
@@ -1341,8 +1341,11 @@ extern "C" uint8_t u8x8_byte_arduino_hw_i2c(U8X8_UNUSED u8x8_t *u8x8, U8X8_UNUSE
     case U8X8_MSG_BYTE_START_TRANSFER:
 #if ARDUINO >= 10600
       /* not sure when the setClock function was introduced, but it is there since 1.6.0 */
-      /* if there is any error with Wire.setClock() just remove this function call */
-      Wire.setClock(u8x8->bus_clock); 
+      /* if there is any error with Wire.setClock() just remove this function call by */
+      /* defining U8x8_DO_NOT_SET_WIRE_CLOCK */
+#ifndef U8x8_DO_NOT_SET_WIRE_CLOCK
+      Wire.setClock(u8x8->bus_clock);
+#endif 
 #endif
       Wire.beginTransmission(u8x8_GetI2CAddress(u8x8)>>1);
       break;
@@ -1374,8 +1377,11 @@ extern "C" uint8_t u8x8_byte_arduino_2nd_hw_i2c(U8X8_UNUSED u8x8_t *u8x8, U8X8_U
     case U8X8_MSG_BYTE_START_TRANSFER:
 #if ARDUINO >= 10600
       /* not sure when the setClock function was introduced, but it is there since 1.6.0 */
-      /* if there is any error with Wire.setClock() just remove this function call */
+      /* if there is any error with Wire.setClock() just remove this function call by */
+      /* defining U8x8_DO_NOT_SET_WIRE_CLOCK */
+#ifndef U8x8_DO_NOT_SET_WIRE_CLOCK
       Wire1.setClock(u8x8->bus_clock); 
+#endif
 #endif
       Wire1.beginTransmission(u8x8_GetI2CAddress(u8x8)>>1);
       break;

--- a/cppsrc/U8x8lib.h
+++ b/cppsrc/U8x8lib.h
@@ -46,6 +46,20 @@
 
 #include "u8x8.h"
 
+/*
+  Uncomment this to switch off Wire.setClock() invocations.
+  This is useful if you connect multiple devices to the same I2C bus that 
+  is used for the monochrome display.
+  For example the Arduino Nano RP2040 connect uses the only I2C bus 
+  already for the internal communication with the integrated on-board components
+  wifi, crypto and accelerometer and does not work correctly if the U8g2 library
+  modifies the I2c clock speed.
+  Instead of uncommenting the line below (which needs a library modification)
+  you can also just add the following define before including the U8x8lib header:
+      #define U8x8_DO_NOT_SET_WIRE_CLOCK
+      #include "U8x8lib.h" 
+*/
+// #define U8x8_DO_NOT_SET_WIRE_CLOCK
 
 /* 
   Uncomment this to enable AVR optimization for I2C 


### PR DESCRIPTION
This pull request proposes to introduce a new global
`#define U8x8_DO_NOT_SET_WIRE_CLOCK`
which disables the Wire.setClock() invocations in     [  Wire.setClock(u8x8->bus_clock); ](https://github.com/olikraus/u8g2/blob/master/cppsrc/U8x8lib.cpp#L1345) and https://github.com/olikraus/u8g2/blob/7014e1d9a69883214b9bbcd64ccf0f7fd8af7964/cppsrc/U8x8lib.cpp#L1378.

Rationale:
while resolving problems over the last few weeks I have stumbled upon multiple people who could only resolve the problem by patching the u8g2 library and removing the setClock() invocations.

The scenario is: the I2c bus used for the monochrome display is also used for other devices.
The libraries of these other devices are initialised and used before the monochrome display is initiating the wire communication.

References:

1) 
https://github.com/arduino-libraries/Arduino_SensorKit/issues/21#issuecomment-1104030135

2) 
https://github.com/olikraus/u8g2/issues/1413#issue-816917931

3)
https://github.com/olikraus/u8g2/issues/1413#issuecomment-791354453

4)
https://github.com/olikraus/u8g2/issues/1134

5)
https://github.com/olikraus/u8g2/discussions/1749

P.S. the suggested solution to call setBusClock() before begin() did not work for me.
My setup:
I use an Arduino Nano RP2040 Connect.
The board already has crypto, wifi and accelerometer connected to the single I2C bus and uses firmware to control the wifi module.
Wifi stopped working as soon as I used u8g2 with the board and an Oled transaction set the clock speed.
I tried multiple different clock speeds with setBusClock() (400k, 100k, 1000k, ...) without success.