### PR TITLE
Cmake: Test for register_component, if not found use std cmake add library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,12 @@ set(COMPONENT_SRCS "csrc/u8x8_setup.c"
                     "csrc/u8x8_d_a2printer.c"
                     "csrc/u8x8_d_st7565.c"
                     "csrc/u8x8_capture.c")
-set(COMPONENT_NAME ".")
 
-register_component()
+if(COMMAND register_component)
+    set(COMPONENT_NAME ".")
+    register_component()
+else()
+    add_library(u8g2 ${COMPONENT_SRCS})
+    target_include_directories(u8g2 PUBLIC ${CMAKE_CURRENT_LIST_DIR}/csrc )
+endif()
+


### PR DESCRIPTION
I wanted to use u8g2 in an environment in which register_component didn't exist, so came up with this simple patch. Hope it's useful. I'm not a cmake expert: if there's a better way I'm all ears! :-)