### PR TITLE
 mingw sys/sdl : "undefined reference to `u8x8_GetMenuEvent'"

### DIFF
--- a/csrc/u8x8_debounce.c
+++ b/csrc/u8x8_debounce.c
@@ -102,7 +102,7 @@ static uint8_t u8x8_find_first_diff(uint8_t a, uint8_t b)
 
 */
 
-#ifdef __unix__xxxxxx_THIS_IS_DISABLED
+#if 1 // #ifndef __unix__
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/csrc/u8x8_debounce.c
+++ b/csrc/u8x8_debounce.c
@@ -102,7 +102,7 @@ static uint8_t u8x8_find_first_diff(uint8_t a, uint8_t b)
 
 */
 
-#if 1 // #ifndef __unix__
+#ifndef __unix__
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
When building apps in  sys/sdl under MinGW,  gcc was failing with "undefined reference to `u8x8_GetMenuEvent'" 
Using MinGW gcc version 6.3.0 (MinGW.org GCC-6.3.0-1) 

