### PR TITLE
Fix font_calc_vref_center off-by-one error

### DIFF
--- a/csrc/u8g2_font.c
+++ b/csrc/u8g2_font.c
@@ -1264,6 +1264,7 @@ u8g2_uint_t u8g2_font_calc_vref_center(u8g2_t *u8g2)
   int8_t tmp;
   tmp = u8g2->font_ref_ascent;
   tmp -= u8g2->font_ref_descent;
+  tmp += 1;
   tmp /= 2;
   tmp += u8g2->font_ref_descent;  
   return tmp;


### PR DESCRIPTION
The goal of `vref_center` is to move the font in the middle between `ascent` and `descent`.

For that, the distance between `ascent` and `descent` is calculated and divided by two. Then, `descent` is added to correct for the fact that we don't need to move the font from the bottom, but from the baseline.

The formula in the code is `(ascent - descent) / 2 + descent`.

The problem is that `ascent - descent` is *not* the height of the font, as both `ascent` and `descent` are *inside* the font bounding box. Just like the range 1-3 (e.g. 1,2,3) does not contain 2 values, as (3-1) would suggest. Instead, for integers, if both ends are included in the range, you need to add one.

So the improved formula is `(ascent - descent + 1) / 2 + descent`.

I came across this when I noticed that vertical centering seems to look 'off'. Additional to the fact that this is mathematically more precise, I feel like it does make a visual difference, especially for smaller fonts. Although it should only matter for fonts where `ascent - descent` is odd.


*EDIT:* I first closed the PR because it seemed just too ridiculous. But then I reopened it, because after a little more trial and error, I'm fairly certain that this bug causes an off-by-one error in `u8g2_font_fourmat_tf`, which is a 5 pixel font. And I think if it only has five pixels, being off by one is a serious problem after all.