### PR TITLE
Checking the definition of MUI_MAX_TEXT_LENGTH

### DIFF
--- a/csrc/mui.h
+++ b/csrc/mui.h
@@ -219,7 +219,9 @@ struct muif_struct
 
 
 /* must be smaller than or equal to 255 */
+#ifndef MUI_MAX_TEXT_LEN
 #define MUI_MAX_TEXT_LEN 41
+#endif
 
 #define MUI_MENU_CACHE_CNT 2
 


### PR DESCRIPTION
This will allow to change the value of MUI_MAX_TEXT_LENGTH at the compilation stage without editing the source code.