### PR TITLE
Fix ATmega328PB build with AVR MiniCore (such as PlatformIO uses)

### DIFF
--- a/cppsrc/U8x8lib.cpp
+++ b/cppsrc/U8x8lib.cpp
@@ -50,6 +50,11 @@
 #    include <i2c_t3.h>
 #  else
 #    include <Wire.h>
+#    ifdef U8X8_HAVE_2ND_HW_I2C
+#      if defined(MINICORE) && defined(__AVR_ATmega328PB__)
+#        include <Wire1.h>
+#      endif
+#    endif
 #  endif
 #endif /* U8X8_HAVE_HW_I2C */
 


### PR DESCRIPTION
This includes the `Wire1.h` header on the ATmega328PB target of AVR MiniCore for using the 2nd I2C port.
Fixes #1890.
