### PR TITLE
polygon: fix sign-compare warnings

### DIFF
--- a/csrc/u8g2_polygon.c
+++ b/csrc/u8g2_polygon.c
@@ -216,17 +216,17 @@ static void pg_hline(pg_struct *pg, u8g2_t *u8g2)
   
   if ( y < 0 )
     return;
-  if ( y >= u8g2_GetDisplayHeight(u8g2) )  // does not work for 256x64 display???
+  if ( y >= (pg_word_t)u8g2_GetDisplayHeight(u8g2) )  // does not work for 256x64 display???
     return;
   if ( x1 < x2 )
   {
     if ( x2 < 0 )
       return;
-    if ( x1 >= u8g2_GetDisplayWidth(u8g2) )
+    if ( x1 >= (pg_word_t)u8g2_GetDisplayWidth(u8g2) )
       return;
     if ( x1 < 0 )
       x1 = 0;
-    if ( x2 >= u8g2_GetDisplayWidth(u8g2) )
+    if ( x2 >= (pg_word_t)u8g2_GetDisplayWidth(u8g2) )
       x2 = u8g2_GetDisplayWidth(u8g2);
     u8g2_DrawHLine(u8g2, x1, y, x2 - x1);
   }
@@ -234,11 +234,11 @@ static void pg_hline(pg_struct *pg, u8g2_t *u8g2)
   {
     if ( x1 < 0 )
       return;
-    if ( x2 >= u8g2_GetDisplayWidth(u8g2) )
+    if ( x2 >= (pg_word_t)u8g2_GetDisplayWidth(u8g2) )
       return;
     if ( x2 < 0 )
       x1 = 0;
-    if ( x1 >= u8g2_GetDisplayWidth(u8g2) )
+    if ( x1 >= (pg_word_t)u8g2_GetDisplayWidth(u8g2) )
       x1 = u8g2_GetDisplayWidth(u8g2);
     u8g2_DrawHLine(u8g2, x2, y, x1 - x2);
   }


### PR DESCRIPTION
Fix warnings such as

```
/home/benpicco/dev/RIOT-BHT/build/pkg/u8g2/csrc/u8g2_polygon.c: In function ‘pg_hline’:
/home/benpicco/dev/RIOT-BHT/build/pkg/u8g2/csrc/u8g2_polygon.c:219:10: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
   if ( y >= u8g2_GetDisplayHeight(u8g2) )  // does not work for 256x64 display???
          ^
/home/benpicco/dev/RIOT-BHT/build/pkg/u8g2/csrc/u8g2_polygon.c:225:13: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
     if ( x1 >= u8g2_GetDisplayWidth(u8g2) )
             ^
/home/benpicco/dev/RIOT-BHT/build/pkg/u8g2/csrc/u8g2_polygon.c:229:13: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
     if ( x2 >= u8g2_GetDisplayWidth(u8g2) )
             ^
/home/benpicco/dev/RIOT-BHT/build/pkg/u8g2/csrc/u8g2_polygon.c:237:13: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
     if ( x2 >= u8g2_GetDisplayWidth(u8g2) )
             ^
/home/benpicco/dev/RIOT-BHT/build/pkg/u8g2/csrc/u8g2_polygon.c:241:13: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
     if ( x1 >= u8g2_GetDisplayWidth(u8g2) )
             ^
cc1: all warnings being treated as errors
```