### PR TITLE
handle '\r'

### DIFF
--- a/cppsrc/U8x8lib.cpp
+++ b/cppsrc/U8x8lib.cpp
@@ -72,6 +72,10 @@ size_t U8X8::write(uint8_t v)
     ty+=dy;
     tx=0;
   }
+  else if ( v == '\r' )
+  {
+    tx=0;
+  }
   else
   {
     uint8_t dx = u8x8_pgm_read(u8x8.font+2);		/* new 2019 format */

--- a/sys/arm-linux/port/U8x8lib.cpp
+++ b/sys/arm-linux/port/U8x8lib.cpp
@@ -60,6 +60,10 @@ size_t U8X8::write(uint8_t v)
     ty+=dy;
     tx=0;
   }
+  else if ( v == '\r' )
+  {
+    tx=0;
+  }
   else
   {
     uint8_t dx = u8x8_pgm_read(u8x8.font+2);		/* new 2019 format */

--- a/sys/rt-thread/port/U8x8lib.cpp
+++ b/sys/rt-thread/port/U8x8lib.cpp
@@ -60,6 +60,10 @@ size_t U8X8::write(uint8_t v)
     ty+=dy;
     tx=0;
   }
+  else if ( v == '\r' )
+  {
+    tx=0;
+  }
   else
   {
     uint8_t dx = u8x8_pgm_read(u8x8.font+2);		/* new 2019 format */


### PR DESCRIPTION
carriage return wasn't handled
spinner is now correctly working

tried making spinner, instead of returning to back of line, it kept writing on and on till going off the screen

minimal loop for reproducing:
```
void loop() {
  u8x8.setFont(u8x8_font_chroma48medium8_r);
  u8x8.setCursor(0, 0);
  int length = 60;
  char spinner[] = "|/-\\";
  for (int i = 0; i < length; i++) {
    // do something
    u8x8.printf("%c\r", spinner[i%4]);
    delay(200);
  }
}
```