### PR TITLE
Bugfix ESP32: I2C pin defs used instead of the SPI pin defs (fixes pin remapping for HW SPI on ESP32 platform)

### DIFF
--- a/cppsrc/U8x8lib.cpp
+++ b/cppsrc/U8x8lib.cpp
@@ -885,6 +885,12 @@ extern "C" uint8_t u8x8_byte_arduino_hw_spi(u8x8_t *u8x8, uint8_t msg, uint8_t a
   {
     case U8X8_MSG_BYTE_SEND:
       
+
+
+#if defined(ESP_PLATFORM)
+      //T.M.L 2023-02-28: use the block transfer function on ESP, which does not overwrite the buffer.
+      SPI.writeBytes((uint8_t*)arg_ptr, arg_int);  
+#else    
       // 1.6.5 offers a block transfer, but the problem is, that the
       // buffer is overwritten with the incoming data
       // so it can not be used...
@@ -893,11 +899,12 @@ extern "C" uint8_t u8x8_byte_arduino_hw_spi(u8x8_t *u8x8, uint8_t msg, uint8_t a
       data = (uint8_t *)arg_ptr;
       while( arg_int > 0 )
       {
-	SPI.transfer((uint8_t)*data);
-	data++;
-	arg_int--;
+        SPI.transfer((uint8_t)*data);
+        data++;
+        arg_int--;
       }
-  
+#endif
+
       break;
     case U8X8_MSG_BYTE_INIT:
       if ( u8x8->bus_clock == 0 ) 	/* issue 769 */
@@ -920,11 +927,11 @@ extern "C" uint8_t u8x8_byte_arduino_hw_spi(u8x8_t *u8x8, uint8_t msg, uint8_t a
 #if defined(ESP_PLATFORM) || defined(ARDUINO_ARCH_ESP32)
       /* ESP32 has the following begin: SPI.begin(int8_t sck=SCK, int8_t miso=MISO, int8_t mosi=MOSI, int8_t ss=-1); */
       /* not sure about ESP8266 */
-      if ( u8x8->pins[U8X8_PIN_I2C_CLOCK] != U8X8_PIN_NONE && u8x8->pins[U8X8_PIN_I2C_DATA] != U8X8_PIN_NONE )
+      if ( u8x8->pins[U8X8_PIN_SPI_CLOCK] != U8X8_PIN_NONE && u8x8->pins[U8X8_PIN_SPI_DATA] != U8X8_PIN_NONE )
       {
 	/* SPI.begin(int8_t sck=SCK, int8_t miso=MISO, int8_t mosi=MOSI, int8_t ss=-1); */
 	/* actually MISO is not used, but what else could be used here??? */
-	SPI.begin(u8x8->pins[U8X8_PIN_I2C_CLOCK], MISO, u8x8->pins[U8X8_PIN_I2C_DATA]);
+	SPI.begin(u8x8->pins[U8X8_PIN_SPI_CLOCK], MISO, u8x8->pins[U8X8_PIN_SPI_DATA]);
       }
       else
       {


### PR DESCRIPTION
Follow-up from:
https://github.com/olikraus/u8g2/issues/377#issuecomment-1448419338

### Platform
Arduino / ESP32-S3 
### Display
OLED SSD1309 (SPI)

### Summary

A custom PCB requires non-standard SPI pin assignments for an SSD1309 OLED display driven by an ESP32-S3.
Everything has been tested functional with bit-banged SW_SPI (U8G2_SSD1309_128X64_NONAME2_F_4W_SW_SPI constructor) on the required "custom" SPI pin assignments.  However, the display manages a very poor 18-19fps frame rate:

![software_bb_20%](https://user-images.githubusercontent.com/3697327/222026934-8fe336ef-9ce2-48e2-8a76-051e20421a3c.JPEG)

It appears in the U8G2 code that there is some proviso for manual pin assignments on the HW_SPI functionality.  However, after creating a custom constructor to utilize this functionality, some notable bugs were discovered in the U8G2 HW_SPI setup functions: namely, that the "manual pin assigments" query the I2C pin assignment registers, instead of the SPI pin assignment registers (which only the latter are set by the custom HW_SPI constructor).
This error results in the manual SPI pin assignments being effectively inaccessible from the U8G2 constructors.

After correcting the "I2C pin assignments" to "SPI pin assignments", the U8G2 library can utilize the desired manual pin assignments with the SSD1309 OLED screen, showing a huge marked improvement in framerate to approximately 230fps (more than 10 times faster than SW_SPI), as seen here:

![230fps_20%](https://user-images.githubusercontent.com/3697327/222026953-7edf0eec-f2c1-49d4-87a7-7168f080c07a.JPEG)

One further improvement that can be made to HW_SPI is to utilize a relatively unknown SPI function for bulk SPI writes on the ESP32, namely "SPI.writeBytes".  (It has been mainstream in Arduino-ESP32 code since at least 2017.)  Comments in the U8G2 code indicate that the "SPI.transfer" function has been found to overwrite the input buffer; "SPI.writeBytes" does not overwrite the input buffer (this has been tested).
Switching to "SPI.writeBytes" results in a further improvement in frame rate to 374fps, an easy 35% improvement from the "byte transfer" frame rate, as seen here:

![324fps_20%](https://user-images.githubusercontent.com/3697327/222026976-3a9cbcc6-b1c5-465d-9609-f8e0a160bc5f.JPEG)
