### PR TITLE
Remove unused variable by using "#if !defined()"

### DIFF
--- a/cppsrc/U8x8lib.cpp
+++ b/cppsrc/U8x8lib.cpp
@@ -881,7 +881,11 @@ extern "C" uint8_t u8x8_byte_arduino_3wire_hw_spi(u8x8_t *u8x8, uint8_t msg, uin
 extern "C" uint8_t u8x8_byte_arduino_hw_spi(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr)
 {
 #ifdef U8X8_HAVE_HW_SPI
+	
+#if !defined(ESP_PLATFORM)
   uint8_t *data;
+#endif
+
   uint8_t internal_spi_mode;
  
   switch(msg)


### PR DESCRIPTION
Environment: Arduino IDE 2.1.0 + ESP32C3

When I use latest u8g2 code for some test in default configuration, I got some error info as follows:

![uTools_1684135273136](https://github.com/olikraus/u8g2/assets/7637623/be30e81e-5920-41d7-958b-475cc7a851ab)

So I use "#if !defined()" to remove this unused variable. After that, it's ok.