### PR TITLE
bar with customized width

### DIFF
--- a/csrc/mui_u8g2.c
+++ b/csrc/mui_u8g2.c
@@ -1106,10 +1106,10 @@ uint8_t mui_u8g2_u8_bar_wm_mse_pf(mui_t *ui, uint8_t msg)
     case MUIF_MSG_CURSOR_SELECT:
     case MUIF_MSG_VALUE_INCREMENT:
       (*value)+=step;
-      if ( *value > max ) *value = min;
+      if ( *value > max ) *value = max;
       break;
     case MUIF_MSG_VALUE_DECREMENT:
-      if ( *value >= min+step ) (*value)-=step; else *value = max;
+      if ( *value >= min+step ) (*value)-=step; else *value = min;
       break;
     case MUIF_MSG_CURSOR_LEAVE:
       break;

--- a/csrc/mui_u8g2.c
+++ b/csrc/mui_u8g2.c
@@ -913,7 +913,7 @@ uint8_t mui_u8g2_u8_min_max_wm_mud_pf(mui_t *ui, uint8_t msg)
       {
         (*value)++;
         if ( *value > max )
-          *value = min;
+          *value = max;
         return 1;
       }
       break;
@@ -921,7 +921,7 @@ uint8_t mui_u8g2_u8_min_max_wm_mud_pf(mui_t *ui, uint8_t msg)
       if ( ui->is_mud )
       {
         if ( *value <= min )
-          *value = max;
+          *value = min;
         else
           (*value)--;
         return 1;
@@ -938,12 +938,13 @@ static void mui_u8g2_u8_bar_draw_wm(mui_t *ui, uint8_t flags) MUI_NOINLINE;
 static void mui_u8g2_u8_bar_draw_wm(mui_t *ui, uint8_t flags)
 {
   u8g2_t *u8g2 = mui_get_U8g2(ui);
-  mui_u8g2_u8_min_max_step_t *vmms= (mui_u8g2_u8_min_max_step_t *)muif_get_data(ui->uif);
+  mui_u8g2_u8_min_max_step_width_t *vmms= (mui_u8g2_u8_min_max_step_width_t *)muif_get_data(ui->uif);
   char buf[4] = "999";
   char *s = buf;
   uint8_t *value = mui_u8g2_u8mms_get_valptr(vmms);
   uint8_t min = mui_u8g2_u8mms_get_min(vmms);
   uint8_t max = mui_u8g2_u8mms_get_max(vmms);
+  uint8_t width = mui_u8g2_u8mms_get_width(vmms);
   uint8_t scale = 0;
   //uint8_t step = mui_u8g2_u8mms_get_step(vmms);
   uint8_t mms_flags = mui_u8g2_u8mms_get_flags(vmms);
@@ -974,10 +975,11 @@ static void mui_u8g2_u8_bar_draw_wm(mui_t *ui, uint8_t flags)
   }
   //mui_u8g2_draw_button_utf(ui, mui_u8g2_get_pi_flags(ui), u8g2_GetStrWidth(u8g2, s)+1, 1, MUI_U8G2_V_PADDING, u8x8_u8toa(*value, cnt));
   //mui_u8g2_draw_button_pi(ui, u8g2_GetStrWidth(u8g2, s)+1, 1, u8x8_u8toa(*value, cnt));
+  uint8_t box_width = (*value)* width / max;
+  w = (width<<scale)+2;
   
-  w += (max<<scale)+2;
   u8g2_DrawFrame( u8g2, x, mui_get_y(ui)-height, w, height);
-  u8g2_DrawBox( u8g2, x+1, mui_get_y(ui)-height+1, (*value)<<scale, height-2);
+  u8g2_DrawBox( u8g2, x+1, mui_get_y(ui)-height+1, (box_width)<<scale, height-2);
   if ( mms_flags & MUI_MMS_SHOW_VALUE )
   {
     w += 2;
@@ -995,7 +997,7 @@ static void mui_u8g2_u8_bar_draw_wm(mui_t *ui, uint8_t flags)
 
 uint8_t mui_u8g2_u8_bar_wm_mse_pi(mui_t *ui, uint8_t msg)
 {
-  mui_u8g2_u8_min_max_step_t *vmms= (mui_u8g2_u8_min_max_step_t *)muif_get_data(ui->uif);
+  mui_u8g2_u8_min_max_step_width_t *vmms= (mui_u8g2_u8_min_max_step_width_t *)muif_get_data(ui->uif);
   uint8_t *value = mui_u8g2_u8mms_get_valptr(vmms);
   uint8_t min = mui_u8g2_u8mms_get_min(vmms);
   uint8_t max = mui_u8g2_u8mms_get_max(vmms);
@@ -1032,7 +1034,7 @@ uint8_t mui_u8g2_u8_bar_wm_mse_pi(mui_t *ui, uint8_t msg)
 
 uint8_t mui_u8g2_u8_bar_wm_mud_pi(mui_t *ui, uint8_t msg)
 {
-  mui_u8g2_u8_min_max_step_t *vmms= (mui_u8g2_u8_min_max_step_t *)muif_get_data(ui->uif);
+  mui_u8g2_u8_min_max_step_width_t *vmms= (mui_u8g2_u8_min_max_step_width_t *)muif_get_data(ui->uif);
   uint8_t *value = mui_u8g2_u8mms_get_valptr(vmms);
   uint8_t min = mui_u8g2_u8mms_get_min(vmms);
   uint8_t max = mui_u8g2_u8mms_get_max(vmms);
@@ -1085,7 +1087,7 @@ uint8_t mui_u8g2_u8_bar_wm_mud_pi(mui_t *ui, uint8_t msg)
 
 uint8_t mui_u8g2_u8_bar_wm_mse_pf(mui_t *ui, uint8_t msg)
 {
-  mui_u8g2_u8_min_max_step_t *vmms= (mui_u8g2_u8_min_max_step_t *)muif_get_data(ui->uif);
+  mui_u8g2_u8_min_max_step_width_t *vmms= (mui_u8g2_u8_min_max_step_width_t *)muif_get_data(ui->uif);
   uint8_t *value = mui_u8g2_u8mms_get_valptr(vmms);
   uint8_t min = mui_u8g2_u8mms_get_min(vmms);
   uint8_t max = mui_u8g2_u8mms_get_max(vmms);
@@ -1121,7 +1123,7 @@ uint8_t mui_u8g2_u8_bar_wm_mse_pf(mui_t *ui, uint8_t msg)
 
 uint8_t mui_u8g2_u8_bar_wm_mud_pf(mui_t *ui, uint8_t msg)
 {
-  mui_u8g2_u8_min_max_step_t *vmms= (mui_u8g2_u8_min_max_step_t *)muif_get_data(ui->uif);
+  mui_u8g2_u8_min_max_step_width_t *vmms= (mui_u8g2_u8_min_max_step_width_t *)muif_get_data(ui->uif);
   uint8_t *value = mui_u8g2_u8mms_get_valptr(vmms);
   uint8_t min = mui_u8g2_u8mms_get_min(vmms);
   uint8_t max = mui_u8g2_u8mms_get_max(vmms);
@@ -1154,7 +1156,7 @@ uint8_t mui_u8g2_u8_bar_wm_mud_pf(mui_t *ui, uint8_t msg)
       {
         (*value)+=step;
         if ( *value > max )
-          *value = min;
+          *value = max;
         return 1;
       }
       break;
@@ -1162,7 +1164,7 @@ uint8_t mui_u8g2_u8_bar_wm_mud_pf(mui_t *ui, uint8_t msg)
       if ( ui->is_mud )
       {
         if ( *value <= min || *value > max)
-          *value = max;
+          *value = min;
         else
           (*value)-=step;
         return 1;

--- a/csrc/mui_u8g2.h
+++ b/csrc/mui_u8g2.h
@@ -224,6 +224,8 @@ uint8_t mui_u8g2_u8_min_max_wm_mud_pf(mui_t *ui, uint8_t msg);  /* GIF, MUIF_U8G
   (void *)((mui_u8g2_u8_min_max_step_width_t [] ) {{ (valptr) MUI_U8G2_COMMA (min) MUI_U8G2_COMMA (max) MUI_U8G2_COMMA (step) MUI_U8G2_COMMA (width) MUI_U8G2_COMMA (flags) }}), \
   (muif))
 
+#define MUIF_U8G2_U8_MIN_MAX_STEP(id, valptr, min, max, step, flags, muif) \
+  MUIF_U8G2_U8_MIN_MAX_STEP_WIDTH(id, valptr, min, max, step, max, flags, muif)
   
 #define MUI_MMS_2X_BAR 0x01
 #define MUI_MMS_4X_BAR 0x02

--- a/csrc/mui_u8g2.h
+++ b/csrc/mui_u8g2.h
@@ -96,16 +96,18 @@ typedef const struct mui_u8g2_u8_min_max_struct mui_u8g2_u8_min_max_t;
 #endif
 
 
-struct mui_u8g2_u8_min_max_step_struct
+struct mui_u8g2_u8_min_max_step_width_struct
 {
   uint8_t *value;
   uint8_t min;
   uint8_t max;
   uint8_t step;
+  uint8_t width;
   uint8_t flags;
 } MUI_PROGMEM;
 
-typedef const struct mui_u8g2_u8_min_max_step_struct mui_u8g2_u8_min_max_step_t;
+typedef const struct mui_u8g2_u8_min_max_step_width_struct mui_u8g2_u8_min_max_step_width_t;
+
 
 #if defined(__GNUC__) && defined(__AVR__)
 #  define mui_u8g2_u8mms_get_step(u8mm) mui_pgm_read(&((u8mm)->step))
@@ -119,6 +121,7 @@ typedef const struct mui_u8g2_u8_min_max_step_struct mui_u8g2_u8_min_max_step_t;
 #  define mui_u8g2_u8mms_get_min(u8mm) ((u8mm)->min)
 #  define mui_u8g2_u8mms_get_max(u8mm) ((u8mm)->max)
 #  define mui_u8g2_u8mms_get_valptr(u8mm) ((u8mm)->value)
+#  define mui_u8g2_u8mms_get_width(u8mm) ((u8mm)->width)
 #endif
 
 
@@ -216,10 +219,11 @@ uint8_t mui_u8g2_u8_min_max_wm_mud_pf(mui_t *ui, uint8_t msg);  /* GIF, MUIF_U8G
 /*===== data = mui_u8g2_u8_min_max_step_t*  =====*/
 
 /* gcc note: the macro uses array compound literals to extend the lifetime in C++, see last section in https://gcc.gnu.org/onlinedocs/gcc/Compound-Literals.html */
-#define MUIF_U8G2_U8_MIN_MAX_STEP(id, valptr, min, max, step, flags, muif) \
+#define MUIF_U8G2_U8_MIN_MAX_STEP_WIDTH(id, valptr, min, max, step, width, flags, muif) \
   MUIF(id, MUIF_CFLAG_IS_CURSOR_SELECTABLE,  \
-  (void *)((mui_u8g2_u8_min_max_step_t [] ) {{ (valptr) MUI_U8G2_COMMA (min) MUI_U8G2_COMMA (max) MUI_U8G2_COMMA (step) MUI_U8G2_COMMA (flags) }}), \
+  (void *)((mui_u8g2_u8_min_max_step_width_t [] ) {{ (valptr) MUI_U8G2_COMMA (min) MUI_U8G2_COMMA (max) MUI_U8G2_COMMA (step) MUI_U8G2_COMMA (width) MUI_U8G2_COMMA (flags) }}), \
   (muif))
+
   
 #define MUI_MMS_2X_BAR 0x01
 #define MUI_MMS_4X_BAR 0x02


### PR DESCRIPTION
When using a bar graph as an indicator, such as for PWM's duty ratio, it can be challenging to draw the graph at a specific position and width. Modifications has been made in the source code to implement such a scenario.