### PR TITLE
Do not use "weak " symbols on Windows

### DIFF
--- a/csrc/u8x8_debounce.c
+++ b/csrc/u8x8_debounce.c
@@ -136,7 +136,7 @@ uint8_t u8x8_GetMenuEvent(u8x8_t *u8x8)
 #define U8X8_DEBOUNCE_WAIT 2
 /* do debounce and return a GPIO msg which indicates the event */
 /* returns 0, if there is no event */
-#if defined(__GNUC__) && !defined(__CYGWIN__)
+#if defined(__GNUC__) && !defined(__WINDOWS__)
 # pragma weak  u8x8_GetMenuEvent
 #endif
 uint8_t u8x8_GetMenuEvent(u8x8_t *u8x8)

--- a/csrc/u8x8_debounce.c
+++ b/csrc/u8x8_debounce.c
@@ -136,7 +136,7 @@ uint8_t u8x8_GetMenuEvent(u8x8_t *u8x8)
 #define U8X8_DEBOUNCE_WAIT 2
 /* do debounce and return a GPIO msg which indicates the event */
 /* returns 0, if there is no event */
-#if defined(__GNUC__) && !defined(__WINDOWS__)
+#if defined(__GNUC__) && !defined(_WIN32)
 # pragma weak  u8x8_GetMenuEvent
 #endif
 uint8_t u8x8_GetMenuEvent(u8x8_t *u8x8)


### PR DESCRIPTION
Not only cygwin, all linker on windows like msvc, mingw, cygwin don't support `weak`.
#393 