### PR TITLE
mui: including missing header and fix some warnings

### DIFF
--- a/csrc/mui.c
+++ b/csrc/mui.c
@@ -300,7 +300,7 @@ void mui_Init(mui_t *ui, void *graphics_data, fds_t *fds, muif_t *muif_tlist, si
   ui->graphics_data = graphics_data;
 }
 
-int mui_find_uif(mui_t *ui, uint8_t id0, uint8_t id1)
+static int mui_find_uif(mui_t *ui, uint8_t id0, uint8_t id1)
 {
   size_t i;
   for( i = 0; i < ui->muif_tcnt; i++ )
@@ -460,7 +460,7 @@ static void mui_loop_over_form(mui_t *ui, uint8_t (*task)(mui_t *ui))
 /*
   n is the form number
 */
-fds_t *mui_find_form(mui_t *ui, uint8_t n)
+static fds_t *mui_find_form(mui_t *ui, uint8_t n)
 {
   fds_t *fds = ui->root_fds;
   uint8_t cmd;
@@ -487,20 +487,20 @@ fds_t *mui_find_form(mui_t *ui, uint8_t n)
 /* === task procedures (arguments for mui_loop_over_form) === */
 /* ui->fds contains the current field */
 
-uint8_t mui_task_draw(mui_t *ui)
+static uint8_t mui_task_draw(mui_t *ui)
 {
   //printf("mui_task_draw fds=%p uif=%p text=%s\n", ui->fds, ui->uif, ui->text);
   muif_get_cb(ui->uif)(ui, MUIF_MSG_DRAW);
   return 0;     /* continue with the loop */
 }
 
-uint8_t mui_task_form_start(mui_t *ui)
+static uint8_t mui_task_form_start(mui_t *ui)
 {
   muif_get_cb(ui->uif)(ui, MUIF_MSG_FORM_START);
   return 0;     /* continue with the loop */
 }
 
-uint8_t mui_task_form_end(mui_t *ui)
+static uint8_t mui_task_form_end(mui_t *ui)
 {
   muif_get_cb(ui->uif)(ui, MUIF_MSG_FORM_END);
   return 0;     /* continue with the loop */
@@ -516,7 +516,7 @@ static uint8_t mui_uif_is_cursor_selectable(mui_t *ui)
   return 0;
 }
 
-uint8_t mui_task_find_prev_cursor_uif(mui_t *ui)
+static uint8_t mui_task_find_prev_cursor_uif(mui_t *ui)
 {
   //if ( muif_get_cflags(ui->uif) & MUIF_CFLAG_IS_CURSOR_SELECTABLE )
   if ( mui_uif_is_cursor_selectable(ui) )
@@ -531,7 +531,7 @@ uint8_t mui_task_find_prev_cursor_uif(mui_t *ui)
   return 0;     /* continue with the loop */
 }
 
-uint8_t mui_task_find_first_cursor_uif(mui_t *ui)
+static uint8_t mui_task_find_first_cursor_uif(mui_t *ui)
 {
   //if ( muif_get_cflags(ui->uif) & MUIF_CFLAG_IS_CURSOR_SELECTABLE )
   if ( mui_uif_is_cursor_selectable(ui) )
@@ -545,7 +545,7 @@ uint8_t mui_task_find_first_cursor_uif(mui_t *ui)
   return 0;     /* continue with the loop */
 }
 
-uint8_t mui_task_find_last_cursor_uif(mui_t *ui)
+static uint8_t mui_task_find_last_cursor_uif(mui_t *ui)
 {
   //if ( muif_get_cflags(ui->uif) & MUIF_CFLAG_IS_CURSOR_SELECTABLE )
   if ( mui_uif_is_cursor_selectable(ui) )
@@ -556,7 +556,7 @@ uint8_t mui_task_find_last_cursor_uif(mui_t *ui)
   return 0;     /* continue with the loop */
 }
 
-uint8_t mui_task_find_next_cursor_uif(mui_t *ui)
+static uint8_t mui_task_find_next_cursor_uif(mui_t *ui)
 {
   //if ( muif_get_cflags(ui->uif) & MUIF_CFLAG_IS_CURSOR_SELECTABLE )
   if ( mui_uif_is_cursor_selectable(ui) )
@@ -575,7 +575,7 @@ uint8_t mui_task_find_next_cursor_uif(mui_t *ui)
   return 0;     /* continue with the loop */
 }
 
-uint8_t mui_task_get_current_cursor_focus_position(mui_t *ui)
+static uint8_t mui_task_get_current_cursor_focus_position(mui_t *ui)
 {
   //if ( muif_get_cflags(ui->uif) & MUIF_CFLAG_IS_CURSOR_SELECTABLE )
   if ( mui_uif_is_cursor_selectable(ui) )
@@ -587,7 +587,7 @@ uint8_t mui_task_get_current_cursor_focus_position(mui_t *ui)
   return 0;     /* continue with the loop */
 }
 
-uint8_t mui_task_read_nth_selectable_field(mui_t *ui)
+static uint8_t mui_task_read_nth_selectable_field(mui_t *ui)
 {
   //if ( muif_get_cflags(ui->uif) & MUIF_CFLAG_IS_CURSOR_SELECTABLE )
   if ( mui_uif_is_cursor_selectable(ui) )
@@ -599,7 +599,7 @@ uint8_t mui_task_read_nth_selectable_field(mui_t *ui)
   return 0;     /* continue with the loop */
 }
 
-uint8_t mui_task_find_execute_on_select_field(mui_t *ui)
+static uint8_t mui_task_find_execute_on_select_field(mui_t *ui)
 {
   if ( muif_get_cflags(ui->uif) & MUIF_CFLAG_IS_EXECUTE_ON_SELECT )
   {
@@ -651,7 +651,7 @@ void mui_Draw(mui_t *ui)
   mui_loop_over_form(ui, mui_task_draw);
 }
 
-void mui_next_field(mui_t *ui)
+static void mui_next_field(mui_t *ui)
 {
   mui_loop_over_form(ui, mui_task_find_next_cursor_uif);
   // ui->cursor_focus_position++;

--- a/csrc/mui_u8g2.c
+++ b/csrc/mui_u8g2.c
@@ -1716,7 +1716,7 @@ uint8_t mui_u8g2_u8_opt_parent_wm_pi(mui_t *ui, uint8_t msg)
 }
 
 
-uint8_t mui_u8g2_u8_opt_child_mse_common(mui_t *ui, uint8_t msg)
+static uint8_t mui_u8g2_u8_opt_child_mse_common(mui_t *ui, uint8_t msg)
 {
   uint8_t *value = (uint8_t *)muif_get_data(ui->uif);
   uint8_t arg = ui->arg;        // remember the arg value, because it might be overwritten

--- a/csrc/mui_u8g2.h
+++ b/csrc/mui_u8g2.h
@@ -65,6 +65,7 @@
 #ifndef MUI_U8G2_H
 #define MUI_U8G2_H
 
+#include "u8g2.h"
 #include "mui.h"
 
 /*==========================================*/


### PR DESCRIPTION
This includes the `u8g2.h` header in `mui_u8g2.h`. The mui_u8g2.h header relies on the `u8g2_uint_t` type, but without
including the header the compiler errors on unknown type.

I think this has generally been hidden because most users probably include "u8g2.h" before "mui_u8g2.h". But just re-ordering those includes can cause the build to fail.



This also fixes warnings about internal functions by adding `static`:

```
mui.c:303:5: warning: no previous prototype for 'mui_find_uif' [-Wmissing-prototypes]
  303 | int mui_find_uif(mui_t *ui, uint8_t id0, uint8_t id1)
      |     ^~~~~~~~~~~~
mui.c:463:8: warning: no previous prototype for 'mui_find_form' [-Wmissing-prototypes]
  463 | fds_t *mui_find_form(mui_t *ui, uint8_t n)
      |        ^~~~~~~~~~~~~
mui.c:490:9: warning: no previous prototype for 'mui_task_draw' [-Wmissing-prototypes]
  490 | uint8_t mui_task_draw(mui_t *ui)
      |         ^~~~~~~~~~~~~
mui.c:497:9: warning: no previous prototype for 'mui_task_form_start' [-Wmissing-prototypes]
  497 | uint8_t mui_task_form_start(mui_t *ui)
      |         ^~~~~~~~~~~~~~~~~~~
mui.c:503:9: warning: no previous prototype for 'mui_task_form_end' [-Wmissing-prototypes]
  503 | uint8_t mui_task_form_end(mui_t *ui)
      |         ^~~~~~~~~~~~~~~~~
mui.c:519:9: warning: no previous prototype for 'mui_task_find_prev_cursor_uif' [-Wmissing-prototypes]
  519 | uint8_t mui_task_find_prev_cursor_uif(mui_t *ui)
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
mui.c:534:9: warning: no previous prototype for 'mui_task_find_first_cursor_uif' [-Wmissing-prototypes]
  534 | uint8_t mui_task_find_first_cursor_uif(mui_t *ui)
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
mui.c:548:9: warning: no previous prototype for 'mui_task_find_last_cursor_uif' [-Wmissing-prototypes]
  548 | uint8_t mui_task_find_last_cursor_uif(mui_t *ui)
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
mui.c:559:9: warning: no previous prototype for 'mui_task_find_next_cursor_uif' [-Wmissing-prototypes]
  559 | uint8_t mui_task_find_next_cursor_uif(mui_t *ui)
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
mui.c:578:9: warning: no previous prototype for 'mui_task_get_current_cursor_focus_position' [-Wmissing-prototypes]
  578 | uint8_t mui_task_get_current_cursor_focus_position(mui_t *ui)
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
mui.c:590:9: warning: no previous prototype for 'mui_task_read_nth_selectable_field' [-Wmissing-prototypes]
  590 | uint8_t mui_task_read_nth_selectable_field(mui_t *ui)
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
mui.c:602:9: warning: no previous prototype for 'mui_task_find_execute_on_select_field' [-Wmissing-prototypes]
  602 | uint8_t mui_task_find_execute_on_select_field(mui_t *ui)
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
mui.c:654:6: warning: no previous prototype for 'mui_next_field' [-Wmissing-prototypes]
  654 | void mui_next_field(mui_t *ui)
```