### PR TITLE
Support using the bitmap device in the Arduino library

### DIFF
--- a/csrc/u8x8_d_bitmap.c
+++ b/csrc/u8x8_d_bitmap.c
@@ -9,7 +9,6 @@
 #include "stdlib.h"	/* malloc */
 #include "stdint.h"	/* uint16_t */
 #include "string.h"	/* memcpy */
-#include "stdio.h"	/* FILE */
 #include "u8g2.h"		/* because of u8g2_Setup... */
 
 /*========================================================*/
@@ -79,65 +78,6 @@ uint8_t u8x8_bitmap_GetPixel(u8x8_bitmap_t *b, uint16_t x, uint16_t y)
   return 1;
 }
 
-static void tga_write_byte(FILE *fp, uint8_t byte)
-{
-  fputc(byte, fp);
-}
-
-static void tga_write_word(FILE *fp, uint16_t word)
-{
-  tga_write_byte(fp, word&255);
-  tga_write_byte(fp, word>>8);
-}
-
-void u8x8_bitmap_SaveTGA(u8x8_bitmap_t *b, const char *name)
-{
-  FILE *fp;
-  uint16_t x, y;
-  
-  fp = fopen(name, "wb");
-  if ( fp != NULL )
-  {
-    tga_write_byte(fp, 0);		/* no ID */
-    tga_write_byte(fp, 0);		/* no color map */
-    tga_write_byte(fp, 2);		/* uncompressed true color */
-    tga_write_word(fp, 0);		
-    tga_write_word(fp, 0);		
-    tga_write_byte(fp, 0);		
-    tga_write_word(fp, 0);		/* x origin */
-    tga_write_word(fp, 0);		/* y origin */
-    tga_write_word(fp, b->pixel_width);		/* width */
-    tga_write_word(fp, b->pixel_height);		/* height */
-    tga_write_byte(fp, 24);		/* color depth */
-    tga_write_byte(fp, 0);	
-    for( y = 0; y < b->pixel_height; y++ )
-    {
-      for( x = 0; x < b->pixel_width; x++ )
-      {
-	if ( u8x8_bitmap_GetPixel(b, x, b->pixel_height-y-1) == 0 )
-	{
-	  tga_write_byte(fp, 255);		/* R */
-	  tga_write_byte(fp, 255);		/* G */
-	  tga_write_byte(fp, 255);		/* B */
-	}
-	else
-	{
-	  tga_write_byte(fp, 0);		/* R */
-	  tga_write_byte(fp, 0);		/* G */
-	  tga_write_byte(fp, 0);		/* B */
-	}
-      }
-    }
-    tga_write_word(fp, 0);
-    tga_write_word(fp, 0);
-    tga_write_word(fp, 0);
-    tga_write_word(fp, 0);
-    fwrite("TRUEVISION-XFILE.", 18, 1, fp);
-    fclose(fp);
-  }
-}
-
-
 /*========================================================*/
 /* global objects for the bitmap */
 
@@ -197,11 +137,6 @@ static void u8x8_DrawBitmapTiles(U8X8_UNUSED u8x8_t *u8x8, uint16_t tx, uint16_t
 uint8_t u8x8_GetBitmapPixel(U8X8_UNUSED u8x8_t *u8x8, uint16_t x, uint16_t y)
 {
   return u8x8_bitmap_GetPixel(&u8x8_bitmap, x, y);
-}
-
-void u8x8_SaveBitmapTGA(U8X8_UNUSED u8x8_t *u8x8, const char *filename)
-{
-  u8x8_bitmap_SaveTGA(&u8x8_bitmap, filename);
 }
 
 /*========================================================*/

--- a/sys/arduino/u8g2_bitmap_dev/HelloWorld/HelloWorld.ino
+++ b/sys/arduino/u8g2_bitmap_dev/HelloWorld/HelloWorld.ino
@@ -1,0 +1,73 @@
+/*
+
+  HelloWorld.ino
+
+  Universal 8bit Graphics Library (https://github.com/olikraus/u8g2/)
+
+  Copyright (c) 2016, olikraus@gmail.com
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification, 
+  are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this list 
+    of conditions and the following disclaimer.
+    
+  * Redistributions in binary form must reproduce the above copyright notice, this 
+    list of conditions and the following disclaimer in the documentation and/or other 
+    materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+*/
+
+#include <Arduino.h>
+#include <U8g2lib.h>
+
+/*
+  This is a memory-backed bitmap rendering example
+*/
+
+#define WIDTH 128
+#define HEIGHT 32
+
+U8G2_BITMAP u8g2(WIDTH, HEIGHT, U8G2_R0);
+
+void setup(void) {
+  Serial.begin(115200);
+  u8g2.begin();  
+}
+
+void loop(void) {
+  u8g2.clearBuffer();					// clear the internal memory
+  u8g2.setFont(u8g2_font_10x20_tr);	// choose a suitable font
+  u8g2.drawStr(0,30,"Hello World!");	// write something to the internal memory
+  u8g2.sendBuffer();					// transfer internal memory to the display
+
+  for (unsigned y=0; y < HEIGHT; ++y) {
+    Serial.print("|");
+    for (unsigned x=0; x < WIDTH; ++x) {
+      if (u8x8_GetBitmapPixel(u8g2.getU8x8(), x, y))
+        Serial.print("X");
+      else
+        Serial.print(" ");
+    }
+    Serial.println("|");
+  }
+  for (unsigned x=0; x < WIDTH + 2; ++x)
+    Serial.print("-");
+  Serial.println();
+
+  delay(1000);  
+}

--- a/sys/arduino/u8g2_bitmap_dev/HelloWorld/Makefile.184.uno
+++ b/sys/arduino/u8g2_bitmap_dev/HelloWorld/Makefile.184.uno
@@ -1,0 +1,147 @@
+#
+# Makefile.184 for Arduino/AVR 
+#
+#  Note:
+#  	Display list make database: make -p -f/dev/null | less
+
+
+# Install path of the arduino software. Requires a '/' at the end.
+ARDUINO_PATH:=/home/matthijs/arduino-1.8.4/
+
+# Board (and prozessor) information: see $(ARDUINO_PATH)hardware/arduino/avr/boards.txt
+# Some examples:
+#	BOARD		DESCRIPTION
+#	uno			Arduino Uno
+#	atmega328	Arduino Duemilanove or Nano w/ ATmega328
+#	diecimila		Arduino Diecimila, Duemilanove, or Nano w/ ATmega168
+#	mega		Arduino Mega
+#	mega2560	Arduino Mega2560
+#	mini			Arduino Mini
+#	lilypad328	LilyPad Arduino w/ ATmega328  
+BOARD:=uno
+
+# The unix device where we can reach the arduino board
+# Uno: /dev/ttyACM0
+# Duemilanove: /dev/ttyUSB0
+AVRDUDE_PORT:=/dev/ttyACM0
+
+
+
+SRC_DIRS=$(ARDUINO_PATH)hardware/arduino/avr/cores/arduino/
+SRC_DIRS+=$(ARDUINO_PATH)hardware/arduino/avr/libraries/SPI/src/
+SRC_DIRS+=$(ARDUINO_PATH)hardware/arduino/avr/libraries/SPI/src/utility/
+SRC_DIRS+=$(ARDUINO_PATH)hardware/arduino/avr/libraries/Wire/src/
+SRC_DIRS+=$(ARDUINO_PATH)hardware/arduino/avr/libraries/Wire/src/utility/
+SRC_DIRS+=../../../../csrc/
+SRC_DIRS+=../../../../cppsrc/
+
+#=== suffixes ===
+.SUFFIXES: .elf .hex .ino
+
+#=== identify user files ===
+INOSRC:=$(shell ls *.ino)
+TARGETNAME=$(basename $(INOSRC))
+
+#=== internal names ===
+LIBNAME:=$(TARGETNAME).a
+ELFNAME:=$(TARGETNAME).elf
+HEXNAME:=$(TARGETNAME).hex
+BINNAME:=$(TARGETNAME).bin
+DISNAME:=$(TARGETNAME).dis
+MAPNAME:=$(TARGETNAME).map
+
+
+#=== replace standard tools ===
+CC:=$(ARDUINO_PATH)hardware/tools/avr/bin/avr-gcc
+CXX:=$(ARDUINO_PATH)hardware/tools/avr/bin/avr-g++
+AR:=$(ARDUINO_PATH)hardware/tools/avr/bin/avr-gcc-ar
+OBJCOPY:=$(ARDUINO_PATH)hardware/tools/avr/bin/avr-objcopy
+OBJDUMP:=$(ARDUINO_PATH)hardware/tools/avr/bin/avr-objdump
+SIZE:=$(ARDUINO_PATH)hardware/tools/avr/bin/avr-size
+
+AVRDUDE = $(ARDUINO_PATH)hardware/tools/avr/bin/avrdude
+
+
+#=== get values from boards.txt ===
+BOARDS_TXT:=$(ARDUINO_PATH)hardware/arduino/avr/boards.txt
+
+# get the MCU value from the $(BOARD).build.mcu variable. For the atmega328 board this is atmega328p
+MCU:=$(shell sed -n -e "s/$(BOARD).build.mcu=\(.*\)/\1/p" $(BOARDS_TXT))
+# get the F_CPU value from the $(BOARD).build.f_cpu variable. For the atmega328 board this is 16000000
+F_CPU:=$(shell sed -n -e "s/$(BOARD).build.f_cpu=\(.*\)/\1/p" $(BOARDS_TXT))
+# get variant subfolder
+VARIANT:=$(shell sed -n -e "s/$(BOARD).build.variant=\(.*\)/\1/p" $(BOARDS_TXT))
+UPLOAD_SPEED:=$(shell sed -n -e "s/$(BOARD).upload.speed=\(.*\)/\1/p" $(BOARDS_TXT))
+# get the AVRDUDE_PROGRAMMER value from the $(BOARD).upload.protocol variable. For the atmega328 board this is stk500
+UPLOAD_PROTOCOL:=$(shell sed -n -e "s/$(BOARD).upload.protocol=\(.*\)/\1/p" $(BOARDS_TXT))
+# use stk500v1, because stk500 will default to stk500v2
+#UPLOAD_PROTOCOL:=stk500v1
+
+AVRDUDE_FLAGS = -V -F
+AVRDUDE_FLAGS += -C $(ARDUINO_PATH)/hardware/tools/avr/etc/avrdude.conf
+AVRDUDE_FLAGS += -p $(MCU)
+AVRDUDE_FLAGS += -P $(AVRDUDE_PORT)
+AVRDUDE_FLAGS += -c $(UPLOAD_PROTOCOL) 
+AVRDUDE_FLAGS += -b $(UPLOAD_SPEED)
+AVRDUDE_FLAGS += -U flash:w:$(HEXNAME)
+
+#=== get all include dirs ===
+INC_DIRS:=. $(SRC_DIRS) $(ARDUINO_PATH)hardware/arduino/avr/variants/$(VARIANT)
+INC_OPTS:=$(addprefix -I,$(INC_DIRS))
+
+#=== get all source files ===
+CSRC:=$(shell ls $(addsuffix *.c,$(SRC_DIRS)) 2>/dev/null) 
+CPPSRC:=$(shell ls $(addsuffix *.cpp,$(SRC_DIRS)) 2>/dev/null)
+
+#=== get all obj files ===
+COBJ:=$(CSRC:.c=.o)
+CPPOBJ:=$(CPPSRC:.cpp=.o)
+OBJ:=$(COBJ) $(CPPOBJ) $(TARGETNAME).o
+
+
+#=== options ===
+
+COMMON_FLAGS = -g -Os -DF_CPU=$(F_CPU) -mmcu=$(MCU) 
+COMMON_FLAGS +=-DARDUINO=10800 -DARDUINO_AVR_UNO -DARDUINO_ARCH_AVR
+COMMON_FLAGS +=-ffunction-sections -fdata-sections -MMD -flto -fno-fat-lto-objects
+COMMON_FLAGS +=$(INC_OPTS)
+CFLAGS:=$(COMMON_FLAGS) -std=gnu99 -Wstrict-prototypes  -Wall -Wextra
+CXXFLAGS:=$(COMMON_FLAGS) -std=gnu++11 -fpermissive -fno-exceptions
+LDFLAGS:=-g -Os  -flto -fuse-linker-plugin -Wl,--gc-sections -mmcu=$(MCU) -Wl,--Map=$(MAPNAME)
+LDLIBS:=-lm
+
+all: $(HEXNAME) $(DISNAME)
+	$(SIZE) $(ELFNAME)
+
+.PHONY: debug
+debug: 
+	@echo $(MCU) $(F_CPU) $(VARIANT) $(UPLOAD_SPEED) $(UPLOAD_PROTOCOL)
+	@echo $(SRC_DIRS)
+	@echo $(CSRC)
+	@echo $(CPPSRC)
+	@echo $(INC_OPTS)
+
+.PHONY: clean
+clean:
+	$(RM) $(OBJ) $(HEXNAME) $(ELFNAME) $(LIBNAME) $(DISNAME) $(MAPNAME) $(BINNAME)
+
+.PHONY: upload
+upload: $(HEXNAME)
+	stty -F $(AVRDUDE_PORT) hupcl
+	$(AVRDUDE) $(AVRDUDE_FLAGS)
+
+# implicit rules
+.ino.cpp:
+	@cp $< $@
+	
+.elf.hex:
+	@$(OBJCOPY) -O ihex -R .eeprom $< $@
+
+# explicit rules
+$(ELFNAME): $(LIBNAME)($(OBJ)) 
+	$(LINK.o) $(LFLAGS) $(LIBNAME) $(LDLIBS) -o $@
+
+$(DISNAME): $(ELFNAME)
+	$(OBJDUMP) -D -S $< > $@
+
+	

--- a/sys/bitmap/cimg_annotate_screenshot/Makefile
+++ b/sys/bitmap/cimg_annotate_screenshot/Makefile
@@ -1,7 +1,7 @@
 CFLAGS = -g -Wall -I../../../csrc/ -ICImg
 CXXFLAGS = $(CFLAGS)
 LDFLAGS = -lpthread
-CSRC = $(wildcard ls ../../../csrc/*.c) ../common/u8x8_d_bitmap.c
+CSRC = $(wildcard ls ../../../csrc/*.c) ../common/*.c
 CPPSRC = main.cpp
 OBJ = $(CSRC:.c=.o) $(CPPSRC:.cpp=.o)
 

--- a/sys/bitmap/common/u8x8_d_bitmap_tga.c
+++ b/sys/bitmap/common/u8x8_d_bitmap_tga.c
@@ -1,0 +1,66 @@
+#include "stdlib.h"	/* malloc */
+#include "stdint.h"	/* uint16_t */
+#include "stdio.h"	/* FILE */
+#include "u8g2.h"
+
+static void tga_write_byte(FILE *fp, uint8_t byte)
+{
+  fputc(byte, fp);
+}
+
+static void tga_write_word(FILE *fp, uint16_t word)
+{
+  tga_write_byte(fp, word&255);
+  tga_write_byte(fp, word>>8);
+}
+
+void u8x8_SaveBitmapTGA(u8x8_t *u8x8, const char *name)
+{
+  FILE *fp;
+  uint16_t x, y;
+
+  uint16_t pixel_width = u8x8->display_info->pixel_width;
+  uint16_t pixel_height = u8x8->display_info->pixel_height;
+  
+  fp = fopen(name, "wb");
+  if ( fp != NULL )
+  {
+    tga_write_byte(fp, 0);		/* no ID */
+    tga_write_byte(fp, 0);		/* no color map */
+    tga_write_byte(fp, 2);		/* uncompressed true color */
+    tga_write_word(fp, 0);		
+    tga_write_word(fp, 0);		
+    tga_write_byte(fp, 0);		
+    tga_write_word(fp, 0);		/* x origin */
+    tga_write_word(fp, 0);		/* y origin */
+    tga_write_word(fp, pixel_width);		/* width */
+    tga_write_word(fp, pixel_height);		/* height */
+    tga_write_byte(fp, 24);		/* color depth */
+    tga_write_byte(fp, 0);	
+
+    for( y = 0; y < pixel_height; y++ )
+    {
+      for( x = 0; x < pixel_width; x++ )
+      {
+	if ( u8x8_GetBitmapPixel(u8x8, x, pixel_height-y-1) == 0 )
+	{
+	  tga_write_byte(fp, 255);		/* R */
+	  tga_write_byte(fp, 255);		/* G */
+	  tga_write_byte(fp, 255);		/* B */
+	}
+	else
+	{
+	  tga_write_byte(fp, 0);		/* R */
+	  tga_write_byte(fp, 0);		/* G */
+	  tga_write_byte(fp, 0);		/* B */
+	}
+      }
+    }
+    tga_write_word(fp, 0);
+    tga_write_word(fp, 0);
+    tga_write_word(fp, 0);
+    tga_write_word(fp, 0);
+    fwrite("TRUEVISION-XFILE.", 18, 1, fp);
+    fclose(fp);
+  }
+}

--- a/sys/bitmap/hello_world/Makefile
+++ b/sys/bitmap/hello_world/Makefile
@@ -1,6 +1,6 @@
 CFLAGS = -g -Wall -I../../../csrc/.
 
-SRC = $(shell ls ../../../csrc/*.c) $(shell ls ../common/u8x8_d_bitmap.c ) main.c
+SRC = $(shell ls ../../../csrc/*.c) $(shell ls ../common/*.c ) main.c
 
 OBJ = $(SRC:.c=.o)
 

--- a/tools/release/arduino/create_release.sh
+++ b/tools/release/arduino/create_release.sh
@@ -122,6 +122,11 @@ cp ../../../sys/arduino/u8g2_page_buffer/LoadFromSD/*.ino ../../../../U8g2_Ardui
 mkdir ../../../../U8g2_Arduino/examples/page_buffer/ButtonEmoticon 
 cp ../../../sys/arduino/u8g2_page_buffer/ButtonEmoticon/*.ino ../../../../U8g2_Arduino/examples/page_buffer/ButtonEmoticon/.
 
+# bitmap devices
+
+mkdir ../../../../U8g2_Arduino/examples/bitmap_dev/HelloWorld
+cp ../../../sys/arduino/u8g2_bitmap_dev/HelloWorld/*.ino ../../../../U8g2_Arduino/examples/bitmap_dev/HelloWorld/.
+
 # mui
 
 mkdir ../../../../U8g2_Arduino/examples/mui/MUIBlink

--- a/tools/release/arduino/create_release.sh
+++ b/tools/release/arduino/create_release.sh
@@ -17,212 +17,212 @@ rm ./../../../../U8g2_Arduino/src/clib/u8x8_d_stdio.c
 
 # page buffer
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/MechCount
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/MechCount
 cp ../../../sys/arduino/u8g2_page_buffer/MechCount/*.ino ../../../../U8g2_Arduino/examples/page_buffer/MechCount/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/Devanagari
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/Devanagari
 cp ../../../sys/arduino/u8g2_page_buffer/Devanagari/*.ino ../../../../U8g2_Arduino/examples/page_buffer/Devanagari/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/UpdatePartly
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/UpdatePartly
 cp ../../../sys/arduino/u8g2_page_buffer/UpdatePartly/*.ino ../../../../U8g2_Arduino/examples/page_buffer/UpdatePartly/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/ClipWindow
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/ClipWindow
 cp ../../../sys/arduino/u8g2_page_buffer/ClipWindow/*.ino ../../../../U8g2_Arduino/examples/page_buffer/ClipWindow/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/StateBufferLoop
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/StateBufferLoop
 cp ../../../sys/arduino/u8g2_page_buffer/StateBufferLoop/*.ino ../../../../U8g2_Arduino/examples/page_buffer/StateBufferLoop/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/Serial
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/Serial
 cp ../../../sys/arduino/u8g2_page_buffer/Serial/*.ino ../../../../U8g2_Arduino/examples/page_buffer/Serial/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/DrawLog
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/DrawLog
 cp ../../../sys/arduino/u8g2_page_buffer/DrawLog/*.ino ../../../../U8g2_Arduino/examples/page_buffer/DrawLog/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/Terminal
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/Terminal
 cp ../../../sys/arduino/u8g2_page_buffer/Terminal/*.ino ../../../../U8g2_Arduino/examples/page_buffer/Terminal/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/IconMenu
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/IconMenu
 cp ../../../sys/arduino/u8g2_page_buffer/IconMenu/*.ino ../../../../U8g2_Arduino/examples/page_buffer/IconMenu/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/Weather
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/Weather
 cp ../../../sys/arduino/u8g2_page_buffer/Weather/*.ino ../../../../U8g2_Arduino/examples/page_buffer/Weather/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/Chinese
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/Chinese
 cp ../../../sys/arduino/u8g2_page_buffer/Chinese/*.ino ../../../../U8g2_Arduino/examples/page_buffer/Chinese/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/Shennong
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/Shennong
 cp ../../../sys/arduino/u8g2_page_buffer/Shennong/*.ino ../../../../U8g2_Arduino/examples/page_buffer/Shennong/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/Shennong
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/Shennong
 cp ../../../sys/arduino/u8g2_full_buffer/Shennong/*.ino ../../../../U8g2_Arduino/examples/full_buffer/Shennong/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/Japanese
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/Japanese
 cp ../../../sys/arduino/u8g2_page_buffer/Japanese/*.ino ../../../../U8g2_Arduino/examples/page_buffer/Japanese/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/Korean
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/Korean
 cp ../../../sys/arduino/u8g2_page_buffer/Korean/*.ino ../../../../U8g2_Arduino/examples/page_buffer/Korean/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/ScrollingText
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/ScrollingText
 cp ../../../sys/arduino/u8g2_page_buffer/ScrollingText/*.ino ../../../../U8g2_Arduino/examples/page_buffer/ScrollingText/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/ContrastTest
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/ContrastTest
 cp ../../../sys/arduino/u8g2_page_buffer/ContrastTest/*.ino ../../../../U8g2_Arduino/examples/page_buffer/ContrastTest/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/DirectAccess
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/DirectAccess
 cp ../../../sys/arduino/u8g2_page_buffer/DirectAccess/*.ino ../../../../U8g2_Arduino/examples/page_buffer/DirectAccess/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/A2Printer
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/A2Printer
 cp ../../../sys/arduino/u8g2_page_buffer/A2Printer/*.ino ../../../../U8g2_Arduino/examples/page_buffer/A2Printer/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/ExtUTF8
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/ExtUTF8
 cp ../../../sys/arduino/u8g2_page_buffer/ExtUTF8/*.ino ../../../../U8g2_Arduino/examples/page_buffer/ExtUTF8/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/FPS
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/FPS
 cp ../../../sys/arduino/u8g2_page_buffer/FPS/*.ino ../../../../U8g2_Arduino/examples/page_buffer/FPS/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/HelloWorld
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/HelloWorld
 cp ../../../sys/arduino/u8g2_page_buffer/HelloWorld/*.ino ../../../../U8g2_Arduino/examples/page_buffer/HelloWorld/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/PrintHelloWorld
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/PrintHelloWorld
 cp ../../../sys/arduino/u8g2_page_buffer/PrintHelloWorld/*.ino ../../../../U8g2_Arduino/examples/page_buffer/PrintHelloWorld/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/PrintProgmem
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/PrintProgmem
 cp ../../../sys/arduino/u8g2_page_buffer/PrintProgmem/*.ino ../../../../U8g2_Arduino/examples/page_buffer/PrintProgmem/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/PrintUTF8
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/PrintUTF8
 cp ../../../sys/arduino/u8g2_page_buffer/PrintUTF8/*.ino ../../../../U8g2_Arduino/examples/page_buffer/PrintUTF8/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/U8g2Logo
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/U8g2Logo
 cp ../../../sys/arduino/u8g2_page_buffer/U8g2Logo/*.ino ../../../../U8g2_Arduino/examples/page_buffer/U8g2Logo/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/FlipMode
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/FlipMode
 cp ../../../sys/arduino/u8g2_page_buffer/FlipMode/*.ino ../../../../U8g2_Arduino/examples/page_buffer/FlipMode/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/SelectionList
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/SelectionList
 cp ../../../sys/arduino/u8g2_page_buffer/SelectionList/*.ino ../../../../U8g2_Arduino/examples/page_buffer/SelectionList/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/GraphicsTest
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/GraphicsTest
 cp ../../../sys/arduino/u8g2_page_buffer/GraphicsTest/*.ino ../../../../U8g2_Arduino/examples/page_buffer/GraphicsTest/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/Clock
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/Clock
 cp ../../../sys/arduino/u8g2_page_buffer/Clock/*.ino ../../../../U8g2_Arduino/examples/page_buffer/Clock/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/XORTest
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/XORTest
 cp ../../../sys/arduino/u8g2_page_buffer/XORTest/*.ino ../../../../U8g2_Arduino/examples/page_buffer/XORTest/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/XBM
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/XBM
 cp ../../../sys/arduino/u8g2_page_buffer/XBM/*.ino ../../../../U8g2_Arduino/examples/page_buffer/XBM/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/PowerSaveTest
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/PowerSaveTest
 cp ../../../sys/arduino/u8g2_page_buffer/PowerSaveTest/*.ino ../../../../U8g2_Arduino/examples/page_buffer/PowerSaveTest/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/LoadFromSD 
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/LoadFromSD 
 cp ../../../sys/arduino/u8g2_page_buffer/LoadFromSD/*.ino ../../../../U8g2_Arduino/examples/page_buffer/LoadFromSD/.
 
-mkdir ../../../../U8g2_Arduino/examples/page_buffer/ButtonEmoticon 
+mkdir -p ../../../../U8g2_Arduino/examples/page_buffer/ButtonEmoticon 
 cp ../../../sys/arduino/u8g2_page_buffer/ButtonEmoticon/*.ino ../../../../U8g2_Arduino/examples/page_buffer/ButtonEmoticon/.
 
 # bitmap devices
 
-mkdir ../../../../U8g2_Arduino/examples/bitmap_dev/HelloWorld
+mkdir -p ../../../../U8g2_Arduino/examples/bitmap_dev/HelloWorld
 cp ../../../sys/arduino/u8g2_bitmap_dev/HelloWorld/*.ino ../../../../U8g2_Arduino/examples/bitmap_dev/HelloWorld/.
 
 # mui
 
-mkdir ../../../../U8g2_Arduino/examples/mui/MUIBlink
+mkdir -p ../../../../U8g2_Arduino/examples/mui/MUIBlink
 cp ../../../sys/arduino/u8g2_page_buffer/MUIBlink/*.ino ../../../../U8g2_Arduino/examples/mui/MUIBlink/.
 
-mkdir ../../../../U8g2_Arduino/examples/mui/MUIMinimal
+mkdir -p ../../../../U8g2_Arduino/examples/mui/MUIMinimal
 cp ../../../sys/arduino/u8g2_page_buffer/MUIMinimal/*.ino ../../../../U8g2_Arduino/examples/mui/MUIMinimal/.
 
-mkdir ../../../../U8g2_Arduino/examples/mui/MUIInput2BtnBounce2
+mkdir -p ../../../../U8g2_Arduino/examples/mui/MUIInput2BtnBounce2
 cp ../../../sys/arduino/u8g2_page_buffer/MUIInput2BtnBounce2/*.ino ../../../../U8g2_Arduino/examples/mui/MUIInput2BtnBounce2/.
 
-mkdir ../../../../U8g2_Arduino/examples/mui/MUIInput3BtnBounce2
+mkdir -p ../../../../U8g2_Arduino/examples/mui/MUIInput3BtnBounce2
 cp ../../../sys/arduino/u8g2_page_buffer/MUIInput3BtnBounce2/*.ino ../../../../U8g2_Arduino/examples/mui/MUIInput3BtnBounce2/.
 
-mkdir ../../../../U8g2_Arduino/examples/mui/MUIInput3BtnWithU8g2
+mkdir -p ../../../../U8g2_Arduino/examples/mui/MUIInput3BtnWithU8g2
 cp ../../../sys/arduino/u8g2_page_buffer/MUIInput3BtnWithU8g2/*.ino ../../../../U8g2_Arduino/examples/mui/MUIInput3BtnWithU8g2/.
 
-mkdir ../../../../U8g2_Arduino/examples/mui/MUIInputSimpleRotary
+mkdir -p ../../../../U8g2_Arduino/examples/mui/MUIInputSimpleRotary
 cp ../../../sys/arduino/u8g2_page_buffer/MUIInputSimpleRotary/*.ino ../../../../U8g2_Arduino/examples/mui/MUIInputSimpleRotary/.
 
-mkdir ../../../../U8g2_Arduino/examples/mui/MUIInputVersatileRotaryEncoder
+mkdir -p ../../../../U8g2_Arduino/examples/mui/MUIInputVersatileRotaryEncoder
 cp ../../../sys/arduino/u8g2_page_buffer/MUIInputVersatileRotaryEncoder/*.ino ../../../../U8g2_Arduino/examples/mui/MUIInputVersatileRotaryEncoder/.
 
-mkdir ../../../../U8g2_Arduino/examples/mui/MUIStopwatch
+mkdir -p ../../../../U8g2_Arduino/examples/mui/MUIStopwatch
 cp ../../../sys/arduino/u8g2_page_buffer/MUIStopwatch/*.ino ../../../../U8g2_Arduino/examples/mui/MUIStopwatch/.
 
-mkdir ../../../../U8g2_Arduino/examples/mui/MUICountDown
+mkdir -p ../../../../U8g2_Arduino/examples/mui/MUICountDown
 cp ../../../sys/arduino/u8g2_page_buffer/MUICountDown/*.ino ../../../../U8g2_Arduino/examples/mui/MUICountDown/.
 
 # games
-mkdir ../../../../U8g2_Arduino/examples/games/LittleRookChess
+mkdir -p ../../../../U8g2_Arduino/examples/games/LittleRookChess
 cp ../../../sys/arduino/u8g2_page_buffer/LittleRookChess/*.ino ../../../../U8g2_Arduino/examples/games/LittleRookChess/.
 
-mkdir ../../../../U8g2_Arduino/examples/games/SpaceTrash
+mkdir -p ../../../../U8g2_Arduino/examples/games/SpaceTrash
 cp ../../../sys/arduino/u8g2_page_buffer/SpaceTrash/*.ino ../../../../U8g2_Arduino/examples/games/SpaceTrash/.
 
 
 # full buffer
 
-mkdir ../../../../U8g2_Arduino/examples/full_buffer/UpdateArea
+mkdir -p ../../../../U8g2_Arduino/examples/full_buffer/UpdateArea
 cp ../../../sys/arduino/u8g2_full_buffer/UpdateArea/*.ino ../../../../U8g2_Arduino/examples/full_buffer/UpdateArea/.
 
-mkdir ../../../../U8g2_Arduino/examples/full_buffer/IconMenu
+mkdir -p ../../../../U8g2_Arduino/examples/full_buffer/IconMenu
 cp ../../../sys/arduino/u8g2_full_buffer/IconMenu/*.ino ../../../../U8g2_Arduino/examples/full_buffer/IconMenu/.
 
-mkdir ../../../../U8g2_Arduino/examples/full_buffer/Weather
+mkdir -p ../../../../U8g2_Arduino/examples/full_buffer/Weather
 cp ../../../sys/arduino/u8g2_full_buffer/Weather/*.ino ../../../../U8g2_Arduino/examples/full_buffer/Weather/.
 
-mkdir ../../../../U8g2_Arduino/examples/full_buffer/HelloWorld
+mkdir -p ../../../../U8g2_Arduino/examples/full_buffer/HelloWorld
 cp ../../../sys/arduino/u8g2_full_buffer/HelloWorld/*.ino ../../../../U8g2_Arduino/examples/full_buffer/HelloWorld/.
 
-mkdir ../../../../U8g2_Arduino/examples/full_buffer/FontUsage
+mkdir -p ../../../../U8g2_Arduino/examples/full_buffer/FontUsage
 cp ../../../sys/arduino/u8g2_full_buffer/FontUsage/*.ino ../../../../U8g2_Arduino/examples/full_buffer/FontUsage/.
 
-mkdir ../../../../U8g2_Arduino/examples/full_buffer/U8g2Logo
+mkdir -p ../../../../U8g2_Arduino/examples/full_buffer/U8g2Logo
 cp ../../../sys/arduino/u8g2_full_buffer/U8g2Logo/*.ino ../../../../U8g2_Arduino/examples/full_buffer/U8g2Logo/.
 
-mkdir ../../../../U8g2_Arduino/examples/full_buffer/PrintUTF8
+mkdir -p ../../../../U8g2_Arduino/examples/full_buffer/PrintUTF8
 cp ../../../sys/arduino/u8g2_full_buffer/PrintUTF8/*.ino ../../../../U8g2_Arduino/examples/full_buffer/PrintUTF8/.
 
-mkdir ../../../../U8g2_Arduino/examples/full_buffer/SelectionList
+mkdir -p ../../../../U8g2_Arduino/examples/full_buffer/SelectionList
 cp ../../../sys/arduino/u8g2_full_buffer/SelectionList/*.ino ../../../../U8g2_Arduino/examples/full_buffer/SelectionList/.
 
-mkdir ../../../../U8g2_Arduino/examples/full_buffer/GraphicsTest
+mkdir -p ../../../../U8g2_Arduino/examples/full_buffer/GraphicsTest
 cp ../../../sys/arduino/u8g2_full_buffer/GraphicsTest/*.ino ../../../../U8g2_Arduino/examples/full_buffer/GraphicsTest/.
 
-mkdir ../../../../U8g2_Arduino/examples/full_buffer/FPS
+mkdir -p ../../../../U8g2_Arduino/examples/full_buffer/FPS
 cp ../../../sys/arduino/u8g2_full_buffer/FPS/*.ino ../../../../U8g2_Arduino/examples/full_buffer/FPS/.
 
-mkdir ../../../../U8g2_Arduino/examples/full_buffer/ScreenShot
+mkdir -p ../../../../U8g2_Arduino/examples/full_buffer/ScreenShot
 cp ../../../sys/arduino/u8g2_full_buffer/ScreenShot/*.ino ../../../../U8g2_Arduino/examples/full_buffer/ScreenShot/.
 
 # u8x8
 
-mkdir ../../../../U8g2_Arduino/examples/u8x8/16x16Font
+mkdir -p ../../../../U8g2_Arduino/examples/u8x8/16x16Font
 cp ../../../sys/arduino/u8x8/16x16Font/*.ino ../../../../U8g2_Arduino/examples/u8x8/16x16Font/.
 
-mkdir ../../../../U8g2_Arduino/examples/u8x8/Terminal
+mkdir -p ../../../../U8g2_Arduino/examples/u8x8/Terminal
 cp ../../../sys/arduino/u8x8/Terminal/*.ino ../../../../U8g2_Arduino/examples/u8x8/Terminal/.
 
-mkdir ../../../../U8g2_Arduino/examples/u8x8/HelloWorld
+mkdir -p ../../../../U8g2_Arduino/examples/u8x8/HelloWorld
 cp ../../../sys/arduino/u8x8/HelloWorld/*.ino ../../../../U8g2_Arduino/examples/u8x8/HelloWorld/.
 
-mkdir ../../../../U8g2_Arduino/examples/u8x8/GraphicsTest
+mkdir -p ../../../../U8g2_Arduino/examples/u8x8/GraphicsTest
 cp ../../../sys/arduino/u8x8/GraphicsTest/*.ino ../../../../U8g2_Arduino/examples/u8x8/GraphicsTest/.
 
-mkdir ../../../../U8g2_Arduino/examples/u8x8/FlipMode
+mkdir -p ../../../../U8g2_Arduino/examples/u8x8/FlipMode
 cp ../../../sys/arduino/u8x8/FlipMode/*.ino ../../../../U8g2_Arduino/examples/u8x8/FlipMode/.
 
-mkdir ../../../../U8g2_Arduino/examples/u8x8/MessageBox
+mkdir -p ../../../../U8g2_Arduino/examples/u8x8/MessageBox
 cp ../../../sys/arduino/u8x8/MessageBox/*.ino ../../../../U8g2_Arduino/examples/u8x8/MessageBox/.
 
-mkdir ../../../../U8g2_Arduino/examples/u8x8/ArduboyTest
+mkdir -p ../../../../U8g2_Arduino/examples/u8x8/ArduboyTest
 cp ../../../sys/arduino/u8x8/ArduboyTest/*.ino ../../../../U8g2_Arduino/examples/u8x8/ArduboyTest/.
 
-mkdir ../../../../U8g2_Arduino/examples/u8x8/Rotate90
+mkdir -p ../../../../U8g2_Arduino/examples/u8x8/Rotate90
 cp ../../../sys/arduino/u8x8/Rotate90/*.ino ../../../../U8g2_Arduino/examples/u8x8/Rotate90/.
 
 


### PR DESCRIPTION
The header files in `csrc` and `cppsrc` contained various declarations related to the bitmap device backend (e..g the `u8g2_SetupBitmap` function and the `U8G2_BITMAP` class), but the definitions of those were in `sys/bitmap/u8x8_d_bitmap.c` and thus not included in default builds and in particular not the Arduino library.

This moves this code into `csrc`, leaving behind the TGA export code that relies on stdio.h, to make this bitmap backend usable in the Arduino library. It also adds an example for how to use this code in the Arduino library.

I tested:
 - The new example From within u8g2 with `Makefile.184.uno`, an unpacked Arduino 1.8.4 tarball and an offical Uno R3.
 - The same with `arduino-cli`, the `arduino:avr` core version 1.8.5 after generating an Arduino library with `tools/release/arduino/create_release.sh`
 - The examples in `sys/bitmap`

The Arduino example sketch outputs the following:

![image](https://github.com/user-attachments/assets/06bcd069-48c9-48cc-8b71-1cdc10eeb43e)
