### PR TITLE
bdfconv: add characters from utf8 text file

### DIFF
--- a/tools/font/bdfconv/bdf_font.c
+++ b/tools/font/bdfconv/bdf_font.c
@@ -707,7 +707,7 @@ int bf_WriteU8G2CByFilename(bf_t *bf, const char *filename, const char *fontname
   xo, yo: offset for 8x8 fonts (font_format==2)
   called from main()
 */
-bf_t *bf_OpenFromFile(const char *bdf_filename, int is_verbose, int bbx_mode, const char *map_str, const char *map_file_name, int font_format, int xo, int yo, int th, int tv)
+bf_t *bf_OpenFromFile(const char *bdf_filename, int is_verbose, int bbx_mode, const char *map_str, const char *map_file_name, const char *utf8_file_name, int font_format, int xo, int yo, int th, int tv)
 {
   bf_t *bf;
 
@@ -726,6 +726,10 @@ bf_t *bf_OpenFromFile(const char *bdf_filename, int is_verbose, int bbx_mode, co
       else
       {
 	bf_Map(bf, map_str);
+      }
+      if ( utf8_file_name[0] != '\0' )
+      {
+	bf_Utf8File(bf, utf8_file_name);
       }
       bf_CalculateSelectedNumberOfGlyphs(bf);
       

--- a/tools/font/bdfconv/bdf_font.h
+++ b/tools/font/bdfconv/bdf_font.h
@@ -130,7 +130,7 @@ void bf_Generate8x8Font(bf_t *bf, int xo, int yo);
 int bf_WriteUCGCByFilename(bf_t *bf, const char *filename, const char *fontname, const char *indent);
 int bf_WriteU8G2CByFilename(bf_t *bf, const char *filename, const char *fontname, const char *indent);
 
-bf_t *bf_OpenFromFile(const char *bdf_filename, int is_verbose, int bbx_mode, const char *map_str, const char *map_file_name, int font_format, int xo, int yo, int th, int tv);
+bf_t *bf_OpenFromFile(const char *bdf_filename, int is_verbose, int bbx_mode, const char *map_str, const char *map_file_name, const char *utf8_file_name, int font_format, int xo, int yo, int th, int tv);
 
 
 /* bdf_parser.c */
@@ -139,6 +139,7 @@ int bf_ParseFile(bf_t *bf, const char *name);
 /* bdf_map.c */
 void bf_Map(bf_t *bf, const char *map_cmd_list);
 int bf_MapFile(bf_t *bf, const char *map_file_name);
+int bf_Utf8File(bf_t *bf, const char *utf8_file_name);
 
 /* bdf_tga.c */
 int tga_init(uint16_t w, uint16_t h);

--- a/tools/font/bdfconv/main.c
+++ b/tools/font/bdfconv/main.c
@@ -134,6 +134,7 @@ void help(void)
   printf("-f <n>      Font format, 0: ucglib font, 1: u8g2 font, 2: u8g2 uncompressed 8x8 font (enforces -b 3)\n");
   printf("-m 'map'    Unicode ASCII mapping\n");
   printf("-M 'mapfile'    Read Unicode ASCII mapping from file 'mapname'\n");
+  printf("-u 'utf8file'    Include all characters from utf8 text file\n");
   printf("-o <file>   C output font file\n");
   printf("-k <file>   C output file with kerning information\n");	
   printf("-p <%%>      Minimum distance for kerning in percent of the global char width (lower values: Smaller gaps, more data)\n");	
@@ -343,6 +344,7 @@ int main(int argc, char **argv)
   int is_verbose = 0;
   char *map_str ="*";
   char *map_filename ="";
+  char *utf8_filename = "";
   char *desc_font_str = "";
   unsigned y;
   
@@ -419,10 +421,13 @@ int main(int argc, char **argv)
     {      
     }
     else if ( get_str_arg(&argv, 'k', &k_filename) != 0 )
-    {      
+    {
     }
     else if ( get_str_arg(&argv, 'M', &map_filename) != 0 )
     {      
+    }
+    else if ( get_str_arg(&argv, 'u', &utf8_filename) != 0 )
+    {
     }
     else
     {
@@ -440,7 +445,7 @@ int main(int argc, char **argv)
   bf_desc_font = NULL;
   if ( desc_font_str[0] != '\0' )
   {
-    bf_desc_font = bf_OpenFromFile(desc_font_str, 0, BDF_BBX_MODE_MINIMAL, "*", "", 0, 0, 0, 1, 1);	/* assume format 0 for description */
+    bf_desc_font = bf_OpenFromFile(desc_font_str, 0, BDF_BBX_MODE_MINIMAL, "*", "", "", 0, 0, 0, 1, 1);	/* assume format 0 for description */
     if ( bf_desc_font == NULL )
     {
       exit(1);
@@ -455,7 +460,7 @@ int main(int argc, char **argv)
   }
   
   /* render the complete font */
-  bf = bf_OpenFromFile(bdf_filename, is_verbose, build_bbx_mode, map_str, map_filename, font_format, xoffset, yoffset, tile_h_size, tile_v_size);
+  bf = bf_OpenFromFile(bdf_filename, is_verbose, build_bbx_mode, map_str, map_filename, utf8_filename, font_format, xoffset, yoffset, tile_h_size, tile_v_size);
   
   if ( bf == NULL )
   {


### PR DESCRIPTION
The goal of this PR is to save flash by reducing a font to only those characters that are actually used.

bdfconv converts a bdf font to an u8g2 font.
This PR adds to bdfconv an option -u filename, where filename is a text file in utf8 format.
All characters in the text file are added to the created u8g2 font.
This is useful if a font contains many characters, but only few characters are used.
Examples are programs that have menus in multiple languages, or use Asian languages like Chinese.
One suggested use is generating a font from strings in firmware source files.

To add the characters in file example.txt to the default ascii set:
```
bdfconv -f 1 -u example.txt -n u8g2_font_unifont -o unifont.h unifont-16.0.02.bdf
```
Two examples where the font is megabytes in size, but the program only needs a kbyte.

### example 1

Print a text in multiple languages in Arduino. Code:
```
void setup(void) {
  u8g2.begin();
  u8g2.enableUTF8Print();
  u8g2.clearBuffer();
  u8g2.setFont(u8g2_font_unifont);
  u8g2.setCursor(0, 15);
  u8g2.println("Hello 您好");
  u8g2.setCursor(0, 31);
  u8g2.println("Здравствуйте");
  u8g2.setCursor(0, 47);
  u8g2.println("こんにちは");
  u8g2.setCursor(0, 63);
  u8g2.println("안녕");
  u8g2.setCursor(0, 79);
  u8g2.print("font ");
  u8g2.print(sizeof(u8g2_font_unifont));
  u8g2.println(" bytes");
  u8g2.sendBuffer();
}
```

- Download  [gnu unifont](https://www.unifoundry.com/unifont/) in bdf format.

- Create a font that contains all of ascii, and all characters in the sketch:
```
bdfconv -f 1  -m '32-127' -u ~/Arduino/bdfconv_test/bdfconv_test.ino -n u8g2_font_unifont -o unifont.h unifont-16.0.02.bdf
```
where bdfconv_test.ino is the sketch source.

- Copy the file unifont.h to your source directory
```
cp unifont.h  ~/Arduino/bdfconv_test/
```

- Compile and run. The text appears on the display. The display is also output in PBM format on the serial port:

![screenshot](https://github.com/user-attachments/assets/73793abd-5a1c-4145-863d-94f7465c5afe)

The font uses 1750 bytes of flash. This is 478 bytes more than same font using only the ascii set.

Arduino sketch attached.
[sketch.zip](https://github.com/user-attachments/files/19655096/sketch.zip)

## example 2
Simplified Chinese, STM32F103, SSH1306 OLED display. Code:
```
void setup(void) {
  int h = 16;
  u8g2.begin();
  u8g2.enableUTF8Print();
  u8g2.clearBuffer();
  u8g2.setFont(u8g2_font_puhuiti_t12);
  u8g2.setCursor(0, h - 1);
  u8g2.print("这是一个易于");
  u8g2.setCursor(0, 2 * h - 1);
  u8g2.print("操作的U8G2");
  u8g2.setCursor(0, 3 * h - 1);
  u8g2.print("字体生成工具.");
  u8g2.sendBuffer();
}
```

- Download [Alibaba PuHuiTi](https://www.alibabafonts.com/#/font) font
- convert the otf font to a bdf bitmap font 
  ```otf2bdf -p 14 -o AlibabaPuHuiTi-3-35-Thin-14.bdf AlibabaPuHuiTi-3-35-Thin.otf```
- create a u8g2 font that has the Chinese characters used in the sketch
  ```bdfconv -f 1 -u bdfconv_test_chinese.ino -n u8g2_font_puhuiti_t14 -o u8g2_font_puhuiti_t14.h  AlibabaPuHuiTi-3-35-Thin-14.bdf```
 where bdfconv__test_chinese.ino is the sketch source.
- compile and run. Display:

![chinese](https://github.com/user-attachments/assets/59690eee-0785-42af-99c1-69b20d420620)

The font uses 4156 bytes of flash. This is 591 bytes more than same font using only the ascii set.

Arduino sketch attached.
[bdfconv_test_chinese.zip](https://github.com/user-attachments/files/19667465/bdfconv_test_chinese.zip)
