### PR TITLE
Fix the implicit declaration of the function

### DIFF
--- a/sys/rt-thread/port/u8g2_port.c
+++ b/sys/rt-thread/port/u8g2_port.c
@@ -10,6 +10,33 @@ static struct rt_i2c_bus_device *i2c_bus = RT_NULL;
 #if defined U8G2_USE_HW_SPI
 static struct rt_spi_device u8g2_spi_dev;
 
+
+static inline void u8g2_port_pin_mode(uint8_t pin, rt_uint8_t mode)
+{
+    if(pin != U8X8_PIN_NONE)
+    {
+        rt_pin_mode(pin, mode);
+    }
+}
+
+static inline void u8g2_port_pin_write(uint8_t pin, uint8_t value)
+{
+    if(pin != U8X8_PIN_NONE)
+    {
+        rt_pin_write(pin, value);
+    }
+}
+
+static inline int u8g2_port_pin_read(uint8_t pin)
+{
+    if(pin != U8X8_PIN_NONE)
+    {
+        return rt_pin_read(pin);
+    }
+
+    return 0;
+}
+
 int rt_hw_spi_config(uint8_t spi_mode, uint32_t max_hz, uint8_t cs_pin )
 {
     rt_err_t res;
@@ -51,33 +78,6 @@ int rt_hw_spi_config(uint8_t spi_mode, uint32_t max_hz, uint8_t cs_pin )
     return RT_EOK;
 }
 #endif /* U8G2_USE_HW_SPI */
-
-
-static inline void u8g2_port_pin_mode(uint8_t pin, rt_uint8_t mode)
-{
-    if(pin != U8X8_PIN_NONE)
-    {
-        rt_pin_mode(pin, mode);
-    }
-}
-
-static inline void u8g2_port_pin_write(uint8_t pin, uint8_t value)
-{
-    if(pin != U8X8_PIN_NONE)
-    {
-        rt_pin_write(pin, value);
-    }
-}
-
-static inline int u8g2_port_pin_read(uint8_t pin)
-{
-    if(pin != U8X8_PIN_NONE)
-    {
-        return rt_pin_read(pin);
-    }
-
-    return 0;
-}
 
 uint8_t u8x8_gpio_and_delay_rtthread(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr)
 {


### PR DESCRIPTION
The `u8g2_port_pin_mode` was called in the function `rt_hw_spi_config`. I noticed that `u8g2_port_pin_mode` is an inline function, but the implementation of this function appears after the call. Therefore, the compiler told me that this is a privacy call.

```
packages\u8g2-official-latest\sys\rt-thread\port\u8g2_port.c:18:5: warning: implicit declaration of function 'u8g2_port_pin_mode' [-Wimplicit-function-declaration]
   18 |     u8g2_port_pin_mode(cs_pin, PIN_MODE_OUTPUT);
      |     ^~~~~~~~~~~~~~~~~~
packages\u8g2-official-latest\sys\rt-thread\port\u8g2_port.c: At top level:
packages\u8g2-official-latest\sys\rt-thread\port\u8g2_port.c:56:20: warning: conflicting types for 'u8g2_port_pin_mode'
   56 | static inline void u8g2_port_pin_mode(uint8_t pin, rt_uint8_t mode)
      |                    ^~~~~~~~~~~~~~~~~~
packages\u8g2-official-latest\sys\rt-thread\port\u8g2_port.c:56:20: error: static declaration of 'u8g2_port_pin_mode' follows non-static declaration
packages\u8g2-official-latest\sys\rt-thread\port\u8g2_port.c:18:5: note: previous implicit declaration of 'u8g2_port_pin_mode' was here
   18 |     u8g2_port_pin_mode(cs_pin, PIN_MODE_OUTPUT);
```

**For the reasons mentioned above, I moved the three inline functions to the earliest positions**