### PR TITLE
Update cmake_minimum_version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.13)
 
 set(COMPONENT_ADD_INCLUDEDIRS csrc)
 file(GLOB COMPONENT_SRCS csrc/*.c)


### PR DESCRIPTION
The version is about to be depricated and needed updating to atleast 3.13 which pico sdk uses. Stops the warning when building.

CMake Deprecation Warning at build/_deps/u8g2-src/CMakeLists.txt:1 (cmake_minimum_required):Compatibility with CMake < 3.10 will be removed from a future version of CMake.