### PR TITLE
mui: uint8_t hex min/max

### DIFF
--- a/csrc/mui_u8g2.c
+++ b/csrc/mui_u8g2.c
@@ -1360,6 +1360,234 @@ uint8_t mui_u8g2_s8_min_max_wm_mud_pf(mui_t *ui, uint8_t msg)
 }
 
 
+/*===============================================================================*/
+/* x8 min max */
+
+static void mui_u8g2_x8_vmm_draw_wm_pi(mui_t *ui) MUI_NOINLINE;
+static void mui_u8g2_x8_vmm_draw_wm_pi(mui_t *ui)
+{
+  u8g2_t *u8g2 = mui_get_U8g2(ui);
+  mui_u8g2_u8_min_max_t *vmm= (mui_u8g2_u8_min_max_t *)muif_get_data(ui->uif);
+  char buf[3] = "FF";
+  char *s = buf;
+  uint8_t *value = mui_u8g2_u8mm_get_valptr(vmm);
+  uint8_t min = mui_u8g2_u8mm_get_min(vmm);
+  uint8_t max = mui_u8g2_u8mm_get_max(vmm);
+  uint8_t cnt = 2;
+
+  if ( *value > max )
+    *value = max;
+  if ( *value <= min )
+    *value = min;
+  if ( max < 16 )
+  {
+    s++;
+    cnt--;
+  }
+  mui_u8g2_draw_button_pi(ui, u8g2_GetStrWidth(u8g2, s)+1, 1, u8x8_u8tox(*value, cnt));
+}
+
+
+uint8_t mui_x8g2_x8_min_max_wm_mse_pi(mui_t *ui, uint8_t msg)
+{
+  mui_u8g2_u8_min_max_t *vmm= (mui_u8g2_u8_min_max_t *)muif_get_data(ui->uif);
+  uint8_t *value = mui_u8g2_u8mm_get_valptr(vmm);
+  uint8_t min = mui_u8g2_u8mm_get_min(vmm);
+  uint8_t max = mui_u8g2_u8mm_get_max(vmm);
+  switch(msg)
+  {
+    case MUIF_MSG_DRAW:
+      mui_u8g2_x8_vmm_draw_wm_pi(ui);
+      break;
+    case MUIF_MSG_FORM_START:
+      break;
+    case MUIF_MSG_FORM_END:
+      break;
+    case MUIF_MSG_CURSOR_ENTER:
+      break;
+    case MUIF_MSG_CURSOR_SELECT:
+    case MUIF_MSG_VALUE_INCREMENT:
+      (*value)++;
+      if ( *value > max ) *value = min;
+      break;
+    case MUIF_MSG_VALUE_DECREMENT:
+      if ( *value > min ) (*value)--; else *value = max;
+      break;
+    case MUIF_MSG_CURSOR_LEAVE:
+      break;
+    case MUIF_MSG_TOUCH_DOWN:
+      break;
+    case MUIF_MSG_TOUCH_UP:
+      break;
+  }
+  return 0;
+}
+
+uint8_t mui_u8g2_x8_min_max_wm_mud_pi(mui_t *ui, uint8_t msg)
+{
+  mui_u8g2_u8_min_max_t *vmm= (mui_u8g2_u8_min_max_t *)muif_get_data(ui->uif);
+  uint8_t *value = mui_u8g2_u8mm_get_valptr(vmm);
+  uint8_t min = mui_u8g2_u8mm_get_min(vmm);
+  uint8_t max = mui_u8g2_u8mm_get_max(vmm);
+  switch(msg)
+  {
+    case MUIF_MSG_DRAW:
+      mui_u8g2_x8_vmm_draw_wm_pi(ui);
+      break;
+    case MUIF_MSG_FORM_START:
+      break;
+    case MUIF_MSG_FORM_END:
+      break;
+    case MUIF_MSG_CURSOR_ENTER:
+      break;
+    case MUIF_MSG_CURSOR_SELECT:
+    case MUIF_MSG_VALUE_INCREMENT:
+    case MUIF_MSG_VALUE_DECREMENT:
+     /* toggle between normal mode and capture next/prev mode */
+      ui->is_mud = !ui->is_mud;
+      break;
+    case MUIF_MSG_CURSOR_LEAVE:
+      break;
+    case MUIF_MSG_TOUCH_DOWN:
+      break;
+    case MUIF_MSG_TOUCH_UP:
+      break;
+    case MUIF_MSG_EVENT_NEXT:
+      if ( ui->is_mud )
+      {
+        (*value)++;
+        if ( *value > max )
+          *value = min;
+        return 1;
+      }
+      break;
+    case MUIF_MSG_EVENT_PREV:
+      if ( ui->is_mud )
+      {
+        if ( *value <= min )
+          *value = max;
+        else
+          (*value)--;
+        return 1;
+      }
+      break;
+  }
+  return 0;
+}
+
+
+
+static void mui_u8g2_x8_vmm_draw_wm_pf(mui_t *ui) MUI_NOINLINE;
+static void mui_u8g2_x8_vmm_draw_wm_pf(mui_t *ui)
+{
+  u8g2_t *u8g2 = mui_get_U8g2(ui);
+  mui_u8g2_u8_min_max_t *vmm= (mui_u8g2_u8_min_max_t *)muif_get_data(ui->uif);
+  char buf[3] = "FF";
+  char *s = buf;
+  uint8_t *value = mui_u8g2_u8mm_get_valptr(vmm);
+  uint8_t min = mui_u8g2_u8mm_get_min(vmm);
+  uint8_t max = mui_u8g2_u8mm_get_max(vmm);
+  uint8_t cnt = 2;
+
+  if ( *value > max )
+    *value = max;
+  if ( *value <= min )
+    *value = min;
+  if ( max < 16 )
+  {
+    s++;
+    cnt--;
+  }
+  mui_u8g2_draw_button_pf(ui, u8g2_GetStrWidth(u8g2, s)+1, 1, u8x8_u8tox(*value, cnt));
+}
+
+
+uint8_t mui_u8g2_x8_min_max_wm_mse_pf(mui_t *ui, uint8_t msg)
+{
+  mui_u8g2_u8_min_max_t *vmm= (mui_u8g2_u8_min_max_t *)muif_get_data(ui->uif);
+  uint8_t *value = mui_u8g2_u8mm_get_valptr(vmm);
+  uint8_t min = mui_u8g2_u8mm_get_min(vmm);
+  uint8_t max = mui_u8g2_u8mm_get_max(vmm);
+  switch(msg)
+  {
+    case MUIF_MSG_DRAW:
+      mui_u8g2_x8_vmm_draw_wm_pf(ui);
+      break;
+    case MUIF_MSG_FORM_START:
+      break;
+    case MUIF_MSG_FORM_END:
+      break;
+    case MUIF_MSG_CURSOR_ENTER:
+      break;
+    case MUIF_MSG_CURSOR_SELECT:
+    case MUIF_MSG_VALUE_INCREMENT:
+      (*value)++;
+      if ( *value > max ) *value = min;
+      break;
+    case MUIF_MSG_VALUE_DECREMENT:
+      if ( *value > min ) (*value)--; else *value = max;
+      break;
+    case MUIF_MSG_CURSOR_LEAVE:
+      break;
+    case MUIF_MSG_TOUCH_DOWN:
+      break;
+    case MUIF_MSG_TOUCH_UP:
+      break;
+  }
+  return 0;
+}
+
+uint8_t mui_u8g2_x8_min_max_wm_mud_pf(mui_t *ui, uint8_t msg)
+{
+  mui_u8g2_u8_min_max_t *vmm= (mui_u8g2_u8_min_max_t *)muif_get_data(ui->uif);
+  uint8_t *value = mui_u8g2_u8mm_get_valptr(vmm);
+  uint8_t min = mui_u8g2_u8mm_get_min(vmm);
+  uint8_t max = mui_u8g2_u8mm_get_max(vmm);
+  switch(msg)
+  {
+    case MUIF_MSG_DRAW:
+      mui_u8g2_x8_vmm_draw_wm_pf(ui);
+      break;
+    case MUIF_MSG_FORM_START:
+      break;
+    case MUIF_MSG_FORM_END:
+      break;
+    case MUIF_MSG_CURSOR_ENTER:
+      break;
+    case MUIF_MSG_CURSOR_SELECT:
+    case MUIF_MSG_VALUE_INCREMENT:
+    case MUIF_MSG_VALUE_DECREMENT:
+      /* toggle between normal mode and capture next/prev mode */
+      ui->is_mud = !ui->is_mud;
+      break;
+    case MUIF_MSG_CURSOR_LEAVE:
+      break;
+    case MUIF_MSG_TOUCH_DOWN:
+      break;
+    case MUIF_MSG_TOUCH_UP:
+      break;
+    case MUIF_MSG_EVENT_NEXT:
+      if ( ui->is_mud )
+      {
+        (*value)++;
+        if ( *value > max )
+          *value = min;
+        return 1;
+      }
+      break;
+    case MUIF_MSG_EVENT_PREV:
+      if ( ui->is_mud )
+      {
+        if ( *value <= min )
+          *value = max;
+        else
+          (*value)--;
+        return 1;
+      }
+      break;
+  }
+  return 0;
+}
 
 
 

--- a/csrc/mui_u8g2.h
+++ b/csrc/mui_u8g2.h
@@ -283,6 +283,12 @@ uint8_t mui_u8g2_u8_min_max_wm_mud_pi(mui_t *ui, uint8_t msg);  /* GIF, MUIF_U8G
 uint8_t mui_u8g2_u8_min_max_wm_mse_pf(mui_t *ui, uint8_t msg);  /* GIF, MUIF_U8G2_U8_MIN_MAX, MUI_XY */
 uint8_t mui_u8g2_u8_min_max_wm_mud_pf(mui_t *ui, uint8_t msg);  /* GIF, MUIF_U8G2_U8_MIN_MAX, MUI_XY */
 
+/* hex format */
+uint8_t mui_u8g2_x8_min_max_wm_mse_pi(mui_t *ui, uint8_t msg);
+uint8_t mui_u8g2_x8_min_max_wm_mud_pi(mui_t *ui, uint8_t msg);
+uint8_t mui_u8g2_x8_min_max_wm_mse_pf(mui_t *ui, uint8_t msg);
+uint8_t mui_u8g2_x8_min_max_wm_mud_pf(mui_t *ui, uint8_t msg);
+
 #define MUIF_U8G2_S8_MIN_MAX(id, valptr, min, max, muif) \
   MUIF(id, MUIF_CFLAG_IS_CURSOR_SELECTABLE,  \
   (void *)((mui_u8g2_s8_min_max_t [] ) {{ (valptr) MUI_U8G2_COMMA (min) MUI_U8G2_COMMA (max)}}), \

--- a/csrc/u8x8.h
+++ b/csrc/u8x8.h
@@ -1094,6 +1094,7 @@ uint8_t u8x8_GetUTF8Len(u8x8_t *u8x8, const char *s);
 /* itoa procedures */
 const char *u8x8_u8toa(uint8_t v, uint8_t d);
 const char *u8x8_s8toa(int8_t v, uint8_t d);
+const char *u8x8_u8tox(uint8_t v, uint8_t d);
 const char *u8x8_u16toa(uint16_t v, uint8_t d);
 const char *u8x8_utoa(uint16_t v);
 

--- a/csrc/u8x8_u8toa.c
+++ b/csrc/u8x8_u8toa.c
@@ -90,4 +90,19 @@ const char *u8x8_s8toa(int8_t v, uint8_t d)
   return buf;
 }
  
- 
+const char *u8x8_u8tox(uint8_t v, uint8_t d)
+{
+  const char hexdigit[]="0123456789ABCDEF";
+  static char buf[3];
+  if ( d == 1 )
+  {
+    buf[0] = hexdigit[v & 0xF];
+    buf[1] = '\0';
+  }
+  else if ( d == 2 )
+  {
+    buf[0] = hexdigit[v >> 4 & 0xF];
+    buf[1] = hexdigit[v & 0xF];
+    buf[2] = '\0';
+  }
+}


### PR DESCRIPTION
This PR extends MUI with displaying uint8_t in hexadecimal. E.g.:
```
MUIF_U8G2_U8_MIN_MAX("D0", &var, 0, 255, mui_u8g2_x8_min_max_wm_mud_pi),
```
This is easilily extended to longer types. E.g. to display uint16_t just place two 8-bit fields next to each other.
