### PR TITLE
mui: add mui_get_text()

### DIFF
--- a/csrc/mui_u8g2.c
+++ b/csrc/mui_u8g2.c
@@ -226,6 +226,11 @@ u8g2_uint_t mui_get_arg(mui_t *ui)
   return ui->arg;
 }
 
+char *mui_get_text(mui_t *ui)
+{
+  return ui->text;
+}
+
 u8g2_t *mui_get_U8g2(mui_t *ui)
 {
   return (u8g2_t *)(ui->graphics_data);

--- a/csrc/mui_u8g2.h
+++ b/csrc/mui_u8g2.h
@@ -186,6 +186,7 @@ typedef const struct mui_u8g2_u8_min_max_step_struct mui_u8g2_u8_min_max_step_t;
 u8g2_uint_t mui_get_x(mui_t *ui);
 u8g2_uint_t mui_get_y(mui_t *ui);
 u8g2_uint_t mui_get_arg(mui_t *ui);
+char *mui_get_text(mui_t *ui);
 u8g2_t *mui_get_U8g2(mui_t *ui);
 
 void mui_u8g2_draw_button_utf(mui_t *ui, u8g2_uint_t flags, u8g2_uint_t width, u8g2_uint_t padding_h, u8g2_uint_t padding_v, const char *text);


### PR DESCRIPTION
mui already has mui_get_x(), mui_get_y(), mui_get_arg().
Add mui_get_text() for custom MUI_XYT and MUI_XYAT helper functions.
