### PR TITLE
rt-thread: take spi bus

### DIFF
--- a/sys/rt-thread/port/u8g2_port.c
+++ b/sys/rt-thread/port/u8g2_port.c
@@ -349,6 +349,7 @@ uint8_t u8x8_byte_rtthread_4wire_hw_spi(u8x8_t *u8x8, uint8_t msg, uint8_t arg_i
             break;
 
         case U8X8_MSG_BYTE_START_TRANSFER:
+            rt_spi_take_bus(&u8g2_spi_dev);
             u8x8_gpio_SetCS(u8x8, u8x8->display_info->chip_enable_level);  
             u8x8->gpio_and_delay_cb(u8x8, U8X8_MSG_DELAY_NANO, u8x8->display_info->post_chip_enable_wait_ns, NULL);
             break;
@@ -356,6 +357,7 @@ uint8_t u8x8_byte_rtthread_4wire_hw_spi(u8x8_t *u8x8, uint8_t msg, uint8_t arg_i
         case U8X8_MSG_BYTE_END_TRANSFER:
             u8x8->gpio_and_delay_cb(u8x8, U8X8_MSG_DELAY_NANO, u8x8->display_info->pre_chip_disable_wait_ns, NULL);
             u8x8_gpio_SetCS(u8x8, u8x8->display_info->chip_disable_level);
+            rt_spi_release_bus(&u8g2_spi_dev);
             break;
 
         default:


### PR DESCRIPTION
rt-thread operating system. If the display shares an spi bus with other devices (e.g. flash, sdcard), get exclusive access to the spi bus during display writes. This avoids problems if one thread is writing to sdcard, while another thread is writing to the display.