### PR TITLE
fix: Build error under rt-thread using only U8G2_USE_HW_I2C

### DIFF
--- a/sys/rt-thread/port/u8g2_port.c
+++ b/sys/rt-thread/port/u8g2_port.c
@@ -9,7 +9,7 @@ static struct rt_i2c_bus_device *i2c_bus = RT_NULL;
 
 #if defined U8G2_USE_HW_SPI
 static struct rt_spi_device u8g2_spi_dev;
-
+#endif
 
 static inline void u8g2_port_pin_mode(uint8_t pin, rt_uint8_t mode)
 {
@@ -37,6 +37,7 @@ static inline int u8g2_port_pin_read(uint8_t pin)
     return 0;
 }
 
+#if defined U8G2_USE_HW_SPI
 int rt_hw_spi_config(uint8_t spi_mode, uint32_t max_hz, uint8_t cs_pin )
 {
     rt_err_t res;


### PR DESCRIPTION
I encountered a build error under rt-thread, using only U8G2_USE_HW_I2C without U8G2_USE_HW_SPI enabled.

I have confirmed this PR is able to fix the issue.

I have attached part of the build error log for reference.

```
linking...
./packages/u8g2-official-latest/sys/rt-thread/port/u8g2_port.o: In function `u8x8_gpio_and_delay_rtthread':
D:\RT-ThreadStudio\workspace\Clock32_Main\Debug/../packages/u8g2-official-latest/sys/rt-thread/port/u8g2_port.c:110: undefined reference to `u8g2_port_pin_mode'
D:\RT-ThreadStudio\workspace\Clock32_Main\Debug/../packages/u8g2-official-latest/sys/rt-thread/port/u8g2_port.c:111: undefined reference to `u8g2_port_pin_mode'
D:\RT-ThreadStudio\workspace\Clock32_Main\Debug/../packages/u8g2-official-latest/sys/rt-thread/port/u8g2_port.c:112: undefined reference to `u8g2_port_pin_mode'
D:\RT-ThreadStudio\workspace\Clock32_Main\Debug/../packages/u8g2-official-latest/sys/rt-thread/port/u8g2_port.c:113: undefined reference to `u8g2_port_pin_mode'
D:\RT-ThreadStudio\workspace\Clock32_Main\Debug/../packages/u8g2-official-latest/sys/rt-thread/port/u8g2_port.c:114: undefined reference to `u8g2_port_pin_mode'
./packages/u8g2-official-latest/sys/rt-thread/port/u8g2_port.o:D:\RT-ThreadStudio\workspace\Clock32_Main\Debug/../packages/u8g2-official-latest/sys/rt-thread/port/u8g2_port.c:117: more undefined references to `u8g2_port_pin_mode' follow
./packages/u8g2-official-latest/sys/rt-thread/port/u8g2_port.o: In function `u8x8_gpio_and_delay_rtthread':
D:\RT-ThreadStudio\workspace\Clock32_Main\Debug/../packages/u8g2-official-latest/sys/rt-thread/port/u8g2_port.c:142: undefined reference to `u8g2_port_pin_write'
D:\RT-ThreadStudio\workspace\Clock32_Main\Debug/../packages/u8g2-official-latest/sys/rt-thread/port/u8g2_port.c:143: undefined reference to `u8g2_port_pin_write'
D:\RT-ThreadStudio\workspace\Clock32_Main\Debug/../packages/u8g2-official-latest/sys/rt-thread/port/u8g2_port.c:144: undefined reference to `u8g2_port_pin_write'
D:\RT-ThreadStudio\workspace\Clock32_Main\Debug/../packages/u8g2-official-latest/sys/rt-thread/port/u8g2_port.c:145: undefined reference to `u8g2_port_pin_write'
D:\RT-ThreadStudio\workspace\Clock32_Main\Debug/../packages/u8g2-official-latest/sys/rt-thread/port/u8g2_port.c:146: undefined reference to `u8g2_port_pin_write'
./packages/u8g2-official-latest/sys/rt-thread/port/u8g2_port.o:D:\RT-ThreadStudio\workspace\Clock32_Main\Debug/../packages/u8g2-official-latest/sys/rt-thread/port/u8g2_port.c:165: more undefined references to `u8g2_port_pin_write' follow
./packages/u8g2-official-latest/sys/rt-thread/port/u8g2_port.o: In function `u8x8_gpio_and_delay_rtthread':
D:\RT-ThreadStudio\workspace\Clock32_Main\Debug/../packages/u8g2-official-latest/sys/rt-thread/port/u8g2_port.c:246: undefined reference to `u8g2_port_pin_read'
collect2.exe: error: ld returned 1 exit status
make: *** [makefile:87: rtthread.elf] Error 1
"make -j16 all" terminated with exit code 2. Build might be incomplete.

21:20:56 Build Failed. 14 errors, 3 warnings. (took 35s.934ms)
```