### PR TITLE
fix: comment unused y in s1d15e06

### DIFF
--- a/csrc/u8x8_d_s1d15e06.c
+++ b/csrc/u8x8_d_s1d15e06.c
@@ -67,7 +67,8 @@ static const uint8_t u8x8_d_s1d15e06_flip1_seq[] = {
 
 uint8_t u8x8_d_s1d15e06_common(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr)
 {
-  uint8_t x, y, c;
+  uint8_t x, c;
+  // uint8_t y;
   uint8_t *ptr;
   switch(msg)
   {
@@ -80,8 +81,8 @@ uint8_t u8x8_d_s1d15e06_common(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void 
 	  u8x8_cad_SendCmd(u8x8, 0xB1);	//Page Address - Row
 	  u8x8_cad_SendArg(u8x8, (((u8x8_tile_t *)arg_ptr)->y_pos));
 
-      y = ((u8x8_tile_t *)arg_ptr)->y_pos;
-      y += u8x8->x_offset;
+      // y = ((u8x8_tile_t *)arg_ptr)->y_pos;
+      // y += u8x8->x_offset;
 
       u8x8_cad_SendCmd(u8x8, 0x13);	/* col */
       u8x8_cad_SendArg(u8x8, x);


### PR DESCRIPTION
Per #2756, I commented the unused `y` variable in s1d15e06.

This seems to address the last compilation issue for [updating](https://github.com/RIOT-OS/RIOT/pull/22081) U8g2 in RIOT-OS.

I don't have this display, so I am unable to test this.