### PR TITLE
fix: pass pins to Wire1.begin() in u8x8_byte_arduino_2nd_hw_i2c for ESP32/ESP8266

### DIFF
--- a/cppsrc/U8x8lib.cpp
+++ b/cppsrc/U8x8lib.cpp
@@ -1391,7 +1391,19 @@ extern "C" uint8_t u8x8_byte_arduino_2nd_hw_i2c(U8X8_UNUSED u8x8_t *u8x8, U8X8_U
     case U8X8_MSG_BYTE_INIT:
       if ( u8x8->bus_clock == 0 ) 	/* issue 769 */
 	u8x8->bus_clock = u8x8->display_info->i2c_bus_clock_100kHz * 100000UL;
+#if defined(ESP8266) || defined(ARDUINO_ARCH_ESP8266) || defined(ESP_PLATFORM) || defined(ARDUINO_ARCH_ESP32)
+      /* for ESP8266/ESP32, Wire1.begin has two more arguments: clock and data */
+      if ( u8x8->pins[U8X8_PIN_I2C_CLOCK] != U8X8_PIN_NONE && u8x8->pins[U8X8_PIN_I2C_DATA] != U8X8_PIN_NONE )
+      {
+	Wire1.begin((int)u8x8->pins[U8X8_PIN_I2C_DATA] , u8x8->pins[U8X8_PIN_I2C_CLOCK]);
+      }
+      else
+      {
+	Wire1.begin();
+      }
+#else
       Wire1.begin();
+#endif
       break;
     case U8X8_MSG_BYTE_SET_DC:
       break;

--- a/sys/arm-linux/port/U8x8lib.cpp
+++ b/sys/arm-linux/port/U8x8lib.cpp
@@ -1360,7 +1360,19 @@ extern "C" uint8_t u8x8_byte_arduino_2nd_hw_i2c(U8X8_UNUSED u8x8_t *u8x8, U8X8_U
     case U8X8_MSG_BYTE_INIT:
       if ( u8x8->bus_clock == 0 ) 	/* issue 769 */
 	u8x8->bus_clock = u8x8->display_info->i2c_bus_clock_100kHz * 100000UL;
+#if defined(ESP8266) || defined(ARDUINO_ARCH_ESP8266) || defined(ESP_PLATFORM) || defined(ARDUINO_ARCH_ESP32)
+      /* for ESP8266/ESP32, Wire1.begin has two more arguments: clock and data */
+      if ( u8x8->pins[U8X8_PIN_I2C_CLOCK] != U8X8_PIN_NONE && u8x8->pins[U8X8_PIN_I2C_DATA] != U8X8_PIN_NONE )
+      {
+	Wire1.begin((int)u8x8->pins[U8X8_PIN_I2C_DATA] , u8x8->pins[U8X8_PIN_I2C_CLOCK]);
+      }
+      else
+      {
+	Wire1.begin();
+      }
+#else
       Wire1.begin();
+#endif
       break;
     case U8X8_MSG_BYTE_SET_DC:
       break;

--- a/sys/rt-thread/port/U8x8lib.cpp
+++ b/sys/rt-thread/port/U8x8lib.cpp
@@ -1360,7 +1360,19 @@ extern "C" uint8_t u8x8_byte_arduino_2nd_hw_i2c(U8X8_UNUSED u8x8_t *u8x8, U8X8_U
     case U8X8_MSG_BYTE_INIT:
       if ( u8x8->bus_clock == 0 ) 	/* issue 769 */
 	u8x8->bus_clock = u8x8->display_info->i2c_bus_clock_100kHz * 100000UL;
+#if defined(ESP8266) || defined(ARDUINO_ARCH_ESP8266) || defined(ESP_PLATFORM) || defined(ARDUINO_ARCH_ESP32)
+      /* for ESP8266/ESP32, Wire1.begin has two more arguments: clock and data */
+      if ( u8x8->pins[U8X8_PIN_I2C_CLOCK] != U8X8_PIN_NONE && u8x8->pins[U8X8_PIN_I2C_DATA] != U8X8_PIN_NONE )
+      {
+	Wire1.begin((int)u8x8->pins[U8X8_PIN_I2C_DATA] , u8x8->pins[U8X8_PIN_I2C_CLOCK]);
+      }
+      else
+      {
+	Wire1.begin();
+      }
+#else
       Wire1.begin();
+#endif
       break;
     case U8X8_MSG_BYTE_SET_DC:
       break;


### PR DESCRIPTION
## Bug

`u8x8_byte_arduino_2nd_hw_i2c` calls `Wire1.begin()` with no arguments on every platform, including ESP32 and ESP8266. This ignores the clock/data pin slots stored in `u8x8->pins[]` by the constructor, so Wire1 initialises on whatever default pins the platform happens to use instead of the pins the user specified. On ESP32 the display silently fails to respond.

## Root cause

`u8x8_byte_arduino_hw_i2c` already has the correct guard (added in the same file):

```cpp
#if defined(ESP8266) || defined(ARDUINO_ARCH_ESP8266) || defined(ESP_PLATFORM) || defined(ARDUINO_ARCH_ESP32)
  if ( u8x8->pins[U8X8_PIN_I2C_CLOCK] != U8X8_PIN_NONE && u8x8->pins[U8X8_PIN_I2C_DATA] != U8X8_PIN_NONE )
    Wire.begin((int)u8x8->pins[U8X8_PIN_I2C_DATA], u8x8->pins[U8X8_PIN_I2C_CLOCK]);
  else
    Wire.begin();
#else
  Wire.begin();
#endif
```

`u8x8_byte_arduino_2nd_hw_i2c` has only:

```cpp
Wire1.begin();   // <-- pins ignored
```

## Fix

Apply the same `#ifdef` pattern to `_2nd_hw_i2c`, substituting `Wire1` for `Wire`. Falls back to `Wire1.begin()` when no pins are set, so behaviour on non-ESP platforms and pin-free constructors is unchanged.

Applied to all three copies of the file:
- `cppsrc/U8x8lib.cpp`
- `sys/arm-linux/port/U8x8lib.cpp`
- `sys/rt-thread/port/U8x8lib.cpp`

## Tested

ESP32-DevKitC 38-pin (ESP32-WROOM), two SSD1306 128×64 OLEDs both at I2C address 0x3C:
- OLED 1 on Wire (GPIO21 SDA / GPIO22 SCL) via `u8x8_byte_arduino_hw_i2c` — already worked
- OLED 2 on Wire1 (GPIO25 SDA / GPIO26 SCL) via `u8x8_byte_arduino_2nd_hw_i2c` — **failed before this fix, works after**