### PR TITLE
Return success after otf2bdf writes a complete font

### DIFF
--- a/tools/font/otf2bdf/otf2bdf.c
+++ b/tools/font/otf2bdf/otf2bdf.c
@@ -1115,7 +1115,7 @@ generate_font(FILE *out, char *iname, char *oname)
      */
     eof = fprintf(out, "ENDFONT\n");
 
-    return eof;
+    return eof == EOF ? -1 : 0;
 }
 
 static int


### PR DESCRIPTION
## Problem

`otf2bdf` writes a valid BDF ending in `ENDFONT`, but `generate_font()` returns the positive character count from the final `fprintf()`. `main()` passes that value to `exit()`, so a successful conversion reports status 8 to shells and build scripts.

## Fix

Return zero after a successful final write while preserving a negative result when `fprintf()` reports `EOF`.

## Verification

- Built the tool from the repository source with GCC, `-Wall -Wextra -Werror`, and suppressions only for existing legacy warnings.
- Reproduced the original behavior with `tools/font/ttf/Abel.ttf`: complete BDF output, final `ENDFONT`, exit status 8.
- Verified the patched tool produces byte-identical BDF output and exits 0.
- Ran ASan/UBSan conversions for `Abel.ttf` and `FreeUniversal-Regular.ttf`; both completed with `ENDFONT` and no sanitizer diagnostics.
- Verified a missing input file still exits nonzero (status 1).

This changes only the host-side font conversion tool; generated firmware is unaffected.
