### PR TITLE
Fix bdfconv mapping mode state leakage

### DIFF
--- a/tools/font/bdfconv/bdf_map.c
+++ b/tools/font/bdfconv/bdf_map.c
@@ -171,13 +171,14 @@ static void get_range(const char **s)
 
 static void map_cmd(const char **s)
 {
+  is_exclude = 0;
+  is_kern_exclude = 0;
+
   if ( **s == '*' )
   {
     range_from = 32;
     range_to = 255;
     map_to = 32;
-    is_exclude = 0;
-    is_kern_exclude = 0;
     
     (*s)++;
     skip_space(s);
@@ -203,7 +204,6 @@ static void map_cmd(const char **s)
   }
   else 
   {
-    is_exclude = 0;
     get_range(s);
     map_to = range_from;
     if ( **s == '>')


### PR DESCRIPTION
## Summary

`bdfconv` keeps its current mapping modes in static state. An `x` range sets `is_kern_exclude`, but a following normal range or `~` exclusion did not clear it. Since the kerning-exclusion branch is checked first, later commands could stop mapping or excluding glyphs.

For example, with `7x13.bdf`:

- `x65,32-127` selected 0 glyphs, while `32-127,x65` selected 95.
- `32-127,x65,~66` selected 95 glyphs instead of excluding glyph 66 and selecting 94.

Reset both mode flags before parsing each comma-separated command so each prefix affects only its own range.

## Verification

- Rebuilt `bdfconv` with MinGW GCC 8.1.0 using `-O4 -Wall -Werror`.
- `x65,32-127` now selects 95 glyphs.
- `32-127,x65,~66` now selects 94 glyphs.
- The order-equivalent `x65,32-127` and `32-127,x65` cases produced identical `helvB18` font and kerning files.
