### PR TITLE
fix(bdfconv): prevent assertion failure when generating very large Unicode fonts (full CJK)

### DIFF
--- a/tools/font/bdfconv/bdf_rle.c
+++ b/tools/font/bdfconv/bdf_rle.c
@@ -804,7 +804,7 @@ void bf_RLECompressAllGlyphs(bf_t *bf)
   1 May 2018: Unicode lookup table 
   */
   bf_Log(bf, "RLE Compress: ASCII gylphs=%d, Unicode glyphs=%d", ascii_glyphs, bf->selected_glyphs-ascii_glyphs);
-  unicode_lookup_table_len = (bf->selected_glyphs-ascii_glyphs) / UNICODE_GLYPHS_PER_LOOKUP_TABLE_ENTRY;
+  unicode_lookup_table_len = (bf->selected_glyphs-ascii_glyphs) / UNICODE_GLYPHS_PER_LOOKUP_TABLE_ENTRY + 1;
   //if ( unicode_lookup_table_len > 1 )		
   //  unicode_lookup_table_len--;			
   bf_Log(bf, "RLE Compress: Glyphs per unicode lookup table entry=%d", UNICODE_GLYPHS_PER_LOOKUP_TABLE_ENTRY);
@@ -883,13 +883,14 @@ void bf_RLECompressAllGlyphs(bf_t *bf)
     }
   }
 
-  /* write pending block to the unicode lookup table, ensure, that there is a table entry available */
-  if ( unicode_lookup_table_pos < unicode_lookup_table_len )
+  /* write pending block to the unicode lookup table, ensure, that there is a table entry available.
+     fill EVERY remaining entry with the 0xffff sentinel so large fonts (full CJK) validate too */
+  while ( unicode_lookup_table_pos < unicode_lookup_table_len )
   {
     bf->target_data[unicode_lookup_table_start+unicode_lookup_table_pos*4+0] = unicode_last_delta>>8;
     bf->target_data[unicode_lookup_table_start+unicode_lookup_table_pos*4+1] = unicode_last_delta&255;
-    bf->target_data[unicode_lookup_table_start+unicode_lookup_table_pos*4+2] = 0xff;	
-    bf->target_data[unicode_lookup_table_start+unicode_lookup_table_pos*4+3] = 0xff;	
+    bf->target_data[unicode_lookup_table_start+unicode_lookup_table_pos*4+2] = 0xff;
+    bf->target_data[unicode_lookup_table_start+unicode_lookup_table_pos*4+3] = 0xff;
     unicode_lookup_table_pos++;
   }
   


### PR DESCRIPTION
## Problem

`bdfconv` aborts with an assertion when generating a font with a very large
number of Unicode glyphs (e.g. the full CJK block U+4E00–U+9FFF, ~21000 glyphs):

```
RLE Compress: Unicode lookup table len=210, written entries=209
Assertion failed!
File: bdf_rle.c, Line 898
Expression: unicode_lookup_table_len == unicode_lookup_table_pos
```

## Root cause

`unicode_lookup_table_len` is computed as `glyph_count / UNICODE_GLYPHS_PER_LOOKUP_TABLE_ENTRY`
(integer division). When the glyph count is not an exact multiple of 101, the
last (partial) block still needs a table entry, but the length calculation
under-allocates by one. The pending-block code only wrote **one** `0xffff`
sentinel entry, so the final table entry was left unfilled and the assert
fired.

## Fix

- Allocate one extra lookup table entry: `+1` on the length.
- Fill **every** remaining entry with the `0xffff` sentinel (`if` → `while`).

## Validation

Generated a full-CJK font (21058 Unicode glyphs, 21270 total) successfully
with `-b 1`. The output was verified byte-for-byte against the reference
rendering (u8g2 C library draws the same text identically).

## Notes

Requires `U8G2_USE_LARGE_FONTS` (auto-defined on unix/arm) when compiling
the generated font on desktop targets.
