### PR TITLE
Prevent dimension underflow in DrawRBox() and DrawRFrame()

### DIFF
--- a/csrc/u8g2_box.c
+++ b/csrc/u8g2_box.c
@@ -87,6 +87,10 @@ void u8g2_DrawFrame(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, u8g2_uint_t w, u
 
 void u8g2_DrawRBox(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, u8g2_uint_t w, u8g2_uint_t h, u8g2_uint_t r)
 {
+
+  if ( r > (w/2) || r > (h/2) )
+    return;
+
   u8g2_uint_t xl, yu;
   u8g2_uint_t yl, xr;
 
@@ -146,6 +150,9 @@ void u8g2_DrawRBox(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, u8g2_uint_t w, u8
 
 void u8g2_DrawRFrame(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, u8g2_uint_t w, u8g2_uint_t h, u8g2_uint_t r)
 {
+  if ( r > (w/2) || r > (h/2) )
+    return;
+  
   u8g2_uint_t xl, yu;
 
 #ifdef U8G2_WITH_INTERSECTION

--- a/csrc/u8g2_box.c
+++ b/csrc/u8g2_box.c
@@ -88,8 +88,10 @@ void u8g2_DrawFrame(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, u8g2_uint_t w, u
 void u8g2_DrawRBox(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, u8g2_uint_t w, u8g2_uint_t h, u8g2_uint_t r)
 {
 
-  if ( r > (w/2) || r > (h/2) )
-    return;
+  if ( r > w / 2 )
+    r = w / 2;
+  if ( r > h / 2)
+    r = h / 2;
 
   u8g2_uint_t xl, yu;
   u8g2_uint_t yl, xr;
@@ -150,8 +152,10 @@ void u8g2_DrawRBox(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, u8g2_uint_t w, u8
 
 void u8g2_DrawRFrame(u8g2_t *u8g2, u8g2_uint_t x, u8g2_uint_t y, u8g2_uint_t w, u8g2_uint_t h, u8g2_uint_t r)
 {
-  if ( r > (w/2) || r > (h/2) )
-    return;
+  if ( r > w / 2 )
+    r = w / 2;
+  if ( r > h / 2)
+    r = h / 2;
   
   u8g2_uint_t xl, yu;
 


### PR DESCRIPTION
## Description

Prevent unsigned integer underflow in `u8g2_DrawRBox()` and `u8g2_DrawRFrame()` when the corner radius is larger than half of the box width or height.

For example, with `h = 7` and `r = 4`, the existing calculation:

```c
hh = h;
hh -= r;
hh -= r;
```
wraps around because u8g2_uint_t is unsigned. The resulting large length can reach the low-level line drawing function and cause an out-of-bounds framebuffer write. This change returns early when the supplied radius cannot fit within the requested dimensions.

## Testing
I reproduced the issue with an SSD1306 128x64 full-buffer setup, where drawing an animated rounded frame caused a framebuffer access crash.
I rebuilt and tested the application with this change, and the crash no
longer occurs.